### PR TITLE
1.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,15 +8,13 @@
 
 ![GitHub License](https://img.shields.io/github/license/defended-net/malwatch) [![Go Report Card](https://goreportcard.com/badge/github.com/defended-net/malwatch)](https://goreportcard.com/report/github.com/defended-net/malwatch)
 
-Malwatch is a fast and lightweight malware scanner written in `go` that is ideal for Linux based web server environments. It is capable of scaling to any requirements and is currently used with some of the internet's largest deployments.
+Malwatch is a fast and lightweight malware scanner written in `go` for Linux based web server environments. It is capable of scaling to any requirements and is in production with some of the internet's largest deployments.
 
-Besides excellent detection rates, key design considerations are low resource usage and high performance. A powerful and easy to understand api is provided to cover your alerting requirements and platform integration.
-
-The web hosting industry is in need for a modern open source solution that is done properly. Our objective is to offer a comparably better solution to commercial products, thereby empowering everyone to have good malware protection.
+Besides excellent detection rates, key design considerations are low resource usage while delivering leading performance. A powerful and easy to understand API is provided to cover your alerting requirements and platform integration.
 
 Real time monitoring is offered by `malwatch-monitor`. The number of files present on the system or volume being created / changed does not influence startup time, memory or cpu usage because a queue design ensures there would always be the same resource usage as an equivalent ondemand file scan. The result is an extremely efficient monitoring presence which would otherwise be impractical due to resource usage.
 
-A complete malware signature set is included with updates provided by our [signature repo](https://github.com/defended-net/malwatch-signatures).
+A complete malware signature set is included with seamless updates provided by our [signature repo](https://github.com/defended-net/malwatch-signatures).
 
 There is tremendous value if malwatch is elected to replace your fleet's existing commercial solution. Please consider sponsoring to help us maintain this and other projects.
 
@@ -25,6 +23,7 @@ There is tremendous value if malwatch is elected to replace your fleet's existin
 - On Demand and Real Time scans.
 - Leading performance with resource usage profile delivered in ~22 MiB memory alongside low cpu footprint even under full load.
 - Comprehensive malware signature set.
+- Submit feature to upload new malware samples.
 - Simple yet powerful API to integrate with your backend and platform. Ideal to improve threat intelligence.
 - Flexible alerting capability with built-in support for PagerDuty, e - mail and custom JSON. Use the API to easily add your own!
 - Complete control over the outcome of malware with the help of `actions`. We include `alert`, `quarantine`, `clean` and `exile` but custom ones can be defined.
@@ -36,15 +35,11 @@ There is tremendous value if malwatch is elected to replace your fleet's existin
 
 Create a directory anywhere you prefer, software is meant to be portable. A common choice is `/opt/malwatch`. Then extract the binary there from the downloaded archive:
 
-    wget https://github.com/defended-net/malwatch/releases/download/v1.0.3/malwatch_1.0.3_linux_amd64.tar.gz
+    wget https://github.com/defended-net/malwatch/releases/download/v1.1.0/malwatch_1.1.0_linux_amd64.tar.gz
     mkdir /opt/malwatch
-    tar -C /opt/malwatch -xzvf malwatch_1.0.3_linux_amd64.tar.gz
+    tar -C /opt/malwatch -xzvf malwatch_1.1.0_linux_amd64.tar.gz
 
-It would be recommended to set up your `PATH`:
-
-    export PATH=$PATH:/opt/malwatch
-
-Alternatively symlinks could be used:
+It would be recommended to integrate it with your `PATH`:
 
     ln -s /opt/malwatch/malwatch /usr/local/bin/malwatch
     ln -s /opt/malwatch/malwatch-monitor /usr/local/bin/malwatch-monitor
@@ -57,15 +52,6 @@ If you are using automation (such as Ansible) and want a clean exit, then `malwa
 
 Optional config files have the `.disabled` file extension. These can be renamed to `.toml` to enable.
 
-## Real Time Scanning
-
-Real time malware scanning is possible with `malwatch-monitor`. A `systemd` unit can automatically be created with `malwatch install systemd`. This is optional - feel free to set up your own or use any preferred setup such as a foreground process or even `screen`. We believe software should be flexible.
-
-Using `systemd`, it is necessary to enable followed by starting it:
-
-    systemctl enable malwatch-monitor
-    systemctl start malwatch-monitor
-
 # Configuration
 
 Some basic config variables are needed for operation and are defined in the file `cfg/cfg.toml`. We should start with `targets`. The term `target` means a group of paths which share a common parent. This is accomplished using regex. 
@@ -76,26 +62,7 @@ Once configured, you are ready to perform your first scan!
 
     malwatch scan /var/www/html
 
-# Actions
-
-Actions are configured in the file `cfg/actions.toml`
-
-An outcome which occurs as a result from a detection is an `action`. Actions are so powerful because they can easily be customised at a granular level. Custom actions can even be created
-
-Each `action` comprises of a `verb` paired with `acter`. Each detection can have multiple `actions`. The lack of any `verb` for a detection means no actions will occur, this can be considered the same as a traditional "whitelist".
-
-The following verbs are bundled with malwatch:
-
-# Verbs
-
-Verb  | Outcome
-------------- | -------------
-`alert` | Notification by means of one or more alerters. We bundle PagerDuty, e - mail and custom JSON.
-`quarantine` | Move detection to a the quarantine path (defined in `cfg/cfg.toml`).
-`exile` | Uploads detection to your `s3` bucket. File is removed after succcessful upload, unless `quarantine` is included as the actions.
-`clean` | Sed based expressions which remove malware automatically. Basic `base64` encoded malware removal expressions are included.
-
-## Crons
+## Scheduling Scans
 
 `cron` can be used to schedule scans at preferred intervals. It is not recommended to use scheduled scans if real time scanning with `malwatch-monitor` is already being used.
 
@@ -104,7 +71,22 @@ The command `crontab -e` is used to add or modify cron jobs. The command field c
     0 0 * * * /opt/malwatch/malwatch signatures update
     0 1 * * * /opt/malwatch/malwatch scan
 
+## Real Time Scanning
+
+Real time malware scanning is possible with `malwatch-monitor`. A `systemd` unit can automatically be created with `malwatch install systemd`. This is optional - feel free to set up your own or use any preferred method such as a foreground process or even `screen`. We believe software should be flexible.
+
+Using `systemd`, it is necessary to `enable` followed by `start`:
+
+    systemctl enable malwatch-monitor
+    systemctl start malwatch-monitor
+
+# Submit Malware Samples
+
+Our API can receive malware samples to improve the signature base. One upload is permitted per week and additional uploads are included for our [Sponsors](https://defended.net/sponsor)
+
 # Platform Integrations
+
+Malwatch can operate as standalone or easily be compatible with any setup.
 
 - cPanel
 
@@ -112,7 +94,7 @@ cPanel is included as a drop - in platform integration. It can be enabled by ren
 
 # Documentation
 
-Quick Start guide, advanced usage, changelog and other resources for both users and developers are available at our [Documentation](https://docs.defended.net/malwatch)
+Advanced usage, changelog and other information for users and developers is available at our [Documentation](https://docs.defended.net/malwatch)
 
 # Community
 

--- a/cmd/malwatch/cli.go
+++ b/cmd/malwatch/cli.go
@@ -14,6 +14,7 @@ import (
 	"github.com/defended-net/malwatch/pkg/cli/restore"
 	"github.com/defended-net/malwatch/pkg/cli/scan"
 	"github.com/defended-net/malwatch/pkg/cli/sig"
+	"github.com/defended-net/malwatch/pkg/cli/submit"
 )
 
 // cmds stores arg:cmd layout.
@@ -24,6 +25,7 @@ var cmds = cli.Sub{
 	"quarantine": quarantine.Cmd(),
 	"exile":      exile.Cmd(),
 	"restore":    restore.Cmd(),
+	"submit":     submit.Cmd(),
 	"signatures": sig.Cmd(),
 	"info":       info.Cmd(),
 	"install":    install.Cmd(),

--- a/cmd/malwatch/cli_test.go
+++ b/cmd/malwatch/cli_test.go
@@ -112,6 +112,14 @@ func TestLayout(t *testing.T) {
 			want: string("sig.Refresh"),
 		},
 
+		"submit": {
+			input: []string{
+				"submit",
+			},
+
+			want: help.ErrSubmit.Error(),
+		},
+
 		"info": {
 			input: []string{
 				"info",

--- a/pkg/boot/env/cfg/secret/secrets.go
+++ b/pkg/boot/env/cfg/secret/secrets.go
@@ -19,6 +19,7 @@ import (
 type Cfg struct {
 	path   string
 	Alerts *Alerts
+	Submit *Submit
 	S3     *S3
 	Git    []*Repo
 }
@@ -58,11 +59,17 @@ type S3 struct {
 	Secret   string `env:"S3_SECRET"`
 }
 
-// Repo represents a git repo.
+// Repo represents git repo.
 type Repo struct {
 	User  string
 	Token string
 	URL   string
+}
+
+// Submit represents sample submissions.
+type Submit struct {
+	Endpoint string `env:"SUBMIT_ENDPOINT"`
+	Key      string `env:"SUBMIT_KEY"`
 }
 
 // New returns a new cfg.
@@ -75,6 +82,8 @@ func New(path string) *Cfg {
 			PagerDuty: &PagerDuty{},
 			SMTP:      &SMTP{},
 		},
+
+		Submit: &Submit{},
 
 		S3: &S3{},
 	}
@@ -112,6 +121,11 @@ func Mock(path string) (*Cfg, error) {
 			JSON:      &JSON{},
 			PagerDuty: &PagerDuty{},
 			SMTP:      &SMTP{},
+		},
+
+		Submit: &Submit{
+			Endpoint: "https://api.defended.net/malwatch/submit",
+			Key:      "",
 		},
 
 		S3: &S3{},

--- a/pkg/boot/env/cfg/secret/secrets_test.go
+++ b/pkg/boot/env/cfg/secret/secrets_test.go
@@ -33,7 +33,11 @@ func TestLoad(t *testing.T) {
 	  Port = 587
 	  User = ""
 	  Pass = ""
-  
+
+  [Submit]
+    Endpoint = ""
+    Key = ""
+
   [S3]
 	Endpoint = ""
 	Region = ""

--- a/pkg/boot/install/install.go
+++ b/pkg/boot/install/install.go
@@ -38,15 +38,13 @@ func Run(env *env.Env) error {
 	}
 
 	// First create needed dirs.
-	dirs := []string{
+	for _, dir := range []string{
 		env.Paths.Cfg.Dir,
 		env.Paths.Alerts.Dir,
 		env.Paths.Sigs.Dir,
 		env.Paths.Plat.Dir,
 		env.Paths.Install.Tmp,
-	}
-
-	for _, dir := range dirs {
+	} {
 		if err := os.MkdirAll(dir, 0750); err != nil {
 			return err
 		}
@@ -63,6 +61,8 @@ func Run(env *env.Env) error {
 
 	env.Cfg.Acts = act.New(env.Paths.Cfg.Acts)
 	env.Cfg.Secrets = secret.New(env.Paths.Cfg.Secrets)
+
+	env.Cfg.Secrets.Submit.Endpoint = "https://api.defended.net/malwatch/submit"
 
 	env.Cfg.Acts.Default = []string{"alert"}
 	env.Cfg.Acts.Clean = act.Clean{
@@ -85,12 +85,10 @@ func Run(env *env.Env) error {
 		},
 	}
 
-	cfgs := []cfg.Cfg{
+	for _, cfg := range []cfg.Cfg{
 		env.Cfg.Acts,
 		env.Cfg.Secrets,
-	}
-
-	for _, cfg := range cfgs {
+	} {
 		if err := fsys.WriteTOML(cfg.Path(), cfg); err != nil {
 			return err
 		}

--- a/pkg/cli/submit/cmd.go
+++ b/pkg/cli/submit/cmd.go
@@ -1,0 +1,18 @@
+// © Roscoe Skeens <rskeens@defended.net>
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package submit
+
+import (
+	"github.com/defended-net/malwatch/pkg/cli"
+	"github.com/defended-net/malwatch/pkg/cli/help"
+)
+
+// Cmd returns the cmd.
+func Cmd() *cli.Cmd {
+	return &cli.Cmd{
+		Help: help.ErrSubmit,
+		Min:  1,
+		Fn:   Do,
+	}
+}

--- a/pkg/cli/submit/cmd_test.go
+++ b/pkg/cli/submit/cmd_test.go
@@ -1,0 +1,38 @@
+// © Roscoe Skeens <rskeens@defended.net>
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package submit
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/defended-net/malwatch/pkg/cli"
+	"github.com/defended-net/malwatch/pkg/cli/help"
+)
+
+func TestCmd(t *testing.T) {
+	var (
+		want = &cli.Cmd{
+			Help: help.ErrSubmit,
+			Min:  1,
+			Fn:   Do,
+		}
+
+		got = Cmd()
+	)
+
+	// Args field is []string, will have to iteratively compare.
+
+	if got.Help != want.Help {
+		t.Errorf("unexpected cmd help result %v, want %v", got.Help, want.Help)
+	}
+
+	if got.Min != want.Min {
+		t.Errorf("unexpected cmd min result %v, want %v", got.Min, want.Min)
+	}
+
+	if fmt.Sprintf("%v", got.Fn) != fmt.Sprintf("%v", want.Fn) {
+		t.Errorf("unexpected cmd fn result %v, want %v", got.Fn, want.Fn)
+	}
+}

--- a/pkg/cli/submit/submit.go
+++ b/pkg/cli/submit/submit.go
@@ -1,0 +1,40 @@
+// © Roscoe Skeens <rskeens@defended.net>
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package submit
+
+import (
+	"fmt"
+	"log/slog"
+	"path/filepath"
+
+	"github.com/defended-net/malwatch/pkg/boot/env"
+	"github.com/defended-net/malwatch/pkg/client/http"
+	"github.com/defended-net/malwatch/pkg/fsys"
+	"golang.org/x/sys/unix"
+)
+
+// Do submits.
+// ./malwatch submit [PATH]
+func Do(env *env.Env, args []string) error {
+	var (
+		path = args[0]
+		stat = &unix.Stat_t{}
+	)
+
+	if !filepath.IsAbs(path) {
+		return fmt.Errorf("%w, %v", fsys.ErrPathNotAbs, path)
+	}
+
+	if err := unix.Stat(path, stat); err != nil {
+		return err
+	}
+
+	if err := http.Submit(env.Cfg.Secrets.Submit, path); err != nil {
+		return err
+	}
+
+	slog.Info("submit: success")
+
+	return nil
+}

--- a/pkg/cli/submit/submit_test.go
+++ b/pkg/cli/submit/submit_test.go
@@ -1,0 +1,115 @@
+// © Roscoe Skeens <rskeens@defended.net>
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package submit
+
+import (
+	"errors"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/defended-net/malwatch/pkg/boot/env"
+	"github.com/defended-net/malwatch/pkg/db"
+	"github.com/defended-net/malwatch/pkg/fsys"
+)
+
+func TestDo(t *testing.T) {
+	env, err := env.Mock(t.Name(), t.TempDir())
+	if err != nil {
+		t.Errorf("env mock error: %v", err)
+	}
+
+	if err := db.Load(env); err != nil {
+		t.Fatalf("db load error: %s", err)
+	}
+
+	path := filepath.Join(t.TempDir(), t.Name())
+
+	file, err := os.Create(path)
+	if err != nil {
+		t.Fatal("file create error:", err)
+	}
+	defer file.Close()
+
+	if err := Do(env, []string{path}); err != nil {
+		t.Errorf("submit error: %v", err)
+	}
+}
+
+func TestDoInvalidPath(t *testing.T) {
+	tests := map[string]struct {
+		input []string
+		want  error
+	}{
+		"invalid": {
+			input: []string{
+				"\\",
+			},
+
+			want: fsys.ErrPathNotAbs,
+		},
+
+		"rel": {
+			input: []string{
+				"target/index.php",
+			},
+
+			want: fsys.ErrPathNotAbs,
+		},
+
+		"file": {
+			input: []string{
+				"index.php",
+			},
+
+			want: fsys.ErrPathNotAbs,
+		},
+
+		"space": {
+			input: []string{
+				" ",
+			},
+
+			want: fsys.ErrPathNotAbs,
+		},
+
+		"none": {
+			input: []string{
+				"",
+			},
+
+			want: fsys.ErrPathNotAbs,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			env, err := env.Mock(t.Name(), t.TempDir())
+			if err != nil {
+				t.Errorf("env mock error: %v", err)
+			}
+
+			if err := Do(env, test.input); !errors.Is(err, test.want) {
+				t.Errorf("unexpected submit result %v, want %v", err, test.want)
+			}
+		})
+	}
+}
+
+func TestDoErrs(t *testing.T) {
+	var (
+		input = []string{filepath.Join(t.TempDir(), t.Name())}
+		want  = fs.ErrNotExist
+	)
+
+	env, err := env.Mock(t.Name(), t.TempDir())
+	if err != nil {
+		t.Errorf("env mock error: %v", err)
+	}
+
+	if err := Do(env, input); !errors.Is(err, want) {
+		t.Errorf("unexpected submit err %v, want %v", err, want)
+	}
+}

--- a/pkg/client/http/errs.go
+++ b/pkg/client/http/errs.go
@@ -6,12 +6,15 @@ package http
 import "errors"
 
 var (
-	// ErrReqPrep means aequest prepare error.
+	// ErrReqPrep means request prepare err.
 	ErrReqPrep = errors.New("http: req prepare error")
 
-	// ErrReqDo means request do error.
+	// ErrReqDo means request do err.
 	ErrReqDo = errors.New("http: req do error")
 
 	// ErrBadStatus means bad status code.
 	ErrBadStatus = errors.New("http: bad status code")
+
+	// ErrSubmit means malware sample submit err.
+	ErrSubmit = errors.New("http: submit malware sample error")
 )

--- a/pkg/client/http/submit.go
+++ b/pkg/client/http/submit.go
@@ -1,0 +1,57 @@
+// © Roscoe Skeens <rskeens@defended.net>
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package http
+
+import (
+	"io"
+	"net/http"
+	"os"
+	"time"
+
+	"github.com/defended-net/malwatch/pkg/boot/env/cfg/secret"
+)
+
+// Submit uploads a malware sample.
+func Submit(secrets *secret.Submit, path string) error {
+	var (
+		rdr, wr = io.Pipe()
+
+		sess = &http.Client{
+			Timeout: 5 * time.Second,
+		}
+
+		hdrs = http.Header{
+			"Authorization": {
+				"Bearer " + secrets.Key,
+			},
+
+			"Content-Type": {
+				"text/plain",
+			},
+		}
+	)
+
+	go func() {
+		defer wr.Close()
+
+		file, err := os.Open(path)
+		if err != nil {
+			return
+		}
+		defer file.Close()
+
+		if _, err = io.Copy(wr, file); err != nil {
+			return
+		}
+	}()
+
+	return Post(
+		sess,
+		hdrs,
+		nil,
+		secrets.Endpoint,
+		rdr,
+		200,
+	)
+}

--- a/pkg/plat/preset/alert/pagerduty/pagerduty.go
+++ b/pkg/plat/preset/alert/pagerduty/pagerduty.go
@@ -4,6 +4,7 @@
 package pagerduty
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"log/slog"
@@ -42,7 +43,7 @@ type Payload struct {
 	Details  *state.Result `json:"custom_details"`
 }
 
-var statusOK = []int{
+var statuses = []int{
 	http.StatusOK,
 	http.StatusAccepted,
 	http.StatusCreated,
@@ -78,7 +79,7 @@ func (sender *Sender) Alert(result *state.Result) error {
 		return err
 	}
 
-	return client.Post(sender.client, nil, nil, sender.cfg.Endpoint, payload, statusOK)
+	return client.Post(sender.client, nil, nil, sender.cfg.Endpoint, bytes.NewBuffer(payload), statuses...)
 }
 
 // NewAlert creates an alert.


### PR DESCRIPTION
feat: [add malware sample submit](https://github.com/defended-net/malwatch/commit/26149060843e68cf863fe8fc11f39c1869f15a2f)

refactor: [http post](https://github.com/defended-net/malwatch/commit/d4e89065a1543c601130ca1eb4b9bafdc5db9766)

docs: [tidy README.md and bump release to 1.1.0](https://github.com/defended-net/malwatch/pull/4/commits/f921afa3ffb655be963e89282bccb1f8087092a0)

New / undetected malware samples can now be submitted to us! Everyone has one upload permitted per week, with additional available to project [Sponsors](https://defended.net/sponsor)

Public and managed signature bases can now feature the latest undetected malware in the wild reported by users.