### PR TITLE
build: cross compile with musl

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -5,8 +5,9 @@ builds:
   main: ./cmd/malwatch
   env:
     - CGO_ENABLED=1
+    - CC=/usr/bin/x86_64-linux-musl-gcc
   ldflags:
-    - -w -s -X github.com/defended-net/malwatch/pkg/boot/env.ver={{.Version}}
+    - -w -s -linkmode external -extldflags -static -X github.com/defended-net/malwatch/pkg/boot/env.ver={{.Version}}
   flags:
     - -trimpath
   goos:
@@ -18,8 +19,9 @@ builds:
   main: ./cmd/malwatch-monitor
   env:
     - CGO_ENABLED=1
+    - CC=/usr/bin/x86_64-linux-musl-gcc
   ldflags:
-    - -w -s -X github.com/defended-net/malwatch/pkg/boot/env.ver={{.Version}}
+    - -w -s -linkmode external -extldflags -static -X github.com/defended-net/malwatch/pkg/boot/env.ver={{.Version}}
   flags:
     - -trimpath
   goos:

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ENV GOOS=linux \
     GOARCH=amd64 \
     CGO_ENABLED=1
 
-RUN apk update && apk add --no-cache gcc linux-headers libc-dev
+RUN apk update && apk add --no-cache gcc libc-dev musl-dev linux-headers
 
 WORKDIR $GOPATH/src/malwatch/
 COPY . .

--- a/Makefile
+++ b/Makefile
@@ -28,4 +28,4 @@ race:
 ## build: compile binary to dir /tmp/malwatch/
 .PHONY: build
 build:
-	go build -trimpath -ldflags="-w -s" -o=/tmp/malwatch/ ./cmd/malwatch
+	CC=/usr/bin/x86_64-linux-musl-gcc go build -trimpath -ldflags="-w -s -linkmode external -extldflags -static" -o=/tmp/malwatch/ ./cmd/malwatch


### PR DESCRIPTION
build: cross compile with musl

We receive many questions concerning compatibility with older versions of `glibc`, in particular CentOS 7 but also default AlmaLinux 8. Certain default AlmaLinux 8 systems can encounter errors based on the installed version of `glibc`.

This change in favour of `musl` adds full support for all AlmaLinux 8 setups and even adds compatibility for end of life CentOS 7.