### PR TITLE
1.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,9 +35,9 @@ There is tremendous value if malwatch is elected to replace your fleet's existin
 
 Create a directory anywhere you prefer, software is meant to be portable. A common choice is `/opt/malwatch`. Then extract the binary there from the downloaded archive:
 
-    wget https://github.com/defended-net/malwatch/releases/download/v1.1.1/malwatch_1.1.1_linux_amd64.tar.gz
+    wget https://github.com/defended-net/malwatch/releases/download/v1.2.0/malwatch_1.2.0_linux_amd64.tar.gz
     mkdir /opt/malwatch
-    tar -C /opt/malwatch -xzvf malwatch_1.1.1_linux_amd64.tar.gz
+    tar -C /opt/malwatch -xzvf malwatch_1.2.0_linux_amd64.tar.gz
 
 It would be recommended to integrate it with your `PATH`:
 

--- a/pkg/boot/env/cfg/act/act_test.go
+++ b/pkg/boot/env/cfg/act/act_test.go
@@ -33,10 +33,10 @@ var (
 	}
 
 	acts = []acter.Acter{
-		acter.Mock(verbs[0]),
-		acter.Mock(verbs[1]),
-		acter.Mock(verbs[2]),
-		acter.Mock(verbs[3]),
+		acter.Mock(verbs[0], true),
+		acter.Mock(verbs[1], true),
+		acter.Mock(verbs[2], true),
+		acter.Mock(verbs[3], true),
 	}
 )
 

--- a/pkg/boot/env/env.go
+++ b/pkg/boot/env/env.go
@@ -123,7 +123,7 @@ func Mock(name string, dir string) (*Env, error) {
 	env := &Env{
 		Opts: &Opts{},
 
-		Plat: plat.Mock(acter.Mock(name)),
+		Plat: plat.Mock(acter.Mock(name, true)),
 
 		Paths: &path.Paths{
 			Install: &path.Install{

--- a/pkg/boot/env/plat/plat.go
+++ b/pkg/boot/env/plat/plat.go
@@ -11,6 +11,7 @@ import (
 	"github.com/defended-net/malwatch/pkg/fsys"
 	"github.com/defended-net/malwatch/pkg/plat"
 	"github.com/defended-net/malwatch/pkg/plat/cpanel"
+	"github.com/defended-net/malwatch/pkg/plat/directadmin"
 	"github.com/defended-net/malwatch/pkg/plat/preset"
 )
 
@@ -21,6 +22,7 @@ func Load(env *env.Env) error {
 
 	plats := []plat.Plat{
 		cpanel.New(env),
+		directadmin.New(env),
 	}
 
 	for _, plat := range plats {

--- a/pkg/boot/env/plat/plat_test.go
+++ b/pkg/boot/env/plat/plat_test.go
@@ -15,6 +15,8 @@ func TestLoad(t *testing.T) {
 		t.Fatalf("env mock error: %v", err)
 	}
 
+	env.Cfg.Acts.Quarantine.Dir = ""
+
 	if err = Load(env); err != nil {
 		t.Errorf("plat load error: %v", err)
 	}

--- a/pkg/cli/exile/exile_test.go
+++ b/pkg/cli/exile/exile_test.go
@@ -36,7 +36,7 @@ func TestDo(t *testing.T) {
 	}
 	defer file.Close()
 
-	env.Plat = plat.Mock(acter.Mock(act.VerbExile))
+	env.Plat = plat.Mock(acter.Mock(act.VerbExile, true))
 
 	if err := Do(env, []string{path}); err != nil {
 		t.Errorf("exile error: %v", err)

--- a/pkg/cli/quarantine/quarantine_test.go
+++ b/pkg/cli/quarantine/quarantine_test.go
@@ -39,7 +39,7 @@ func TestDo(t *testing.T) {
 		t.Errorf("sigs mock error: %v", err)
 	}
 
-	env.Plat = plat.Mock(acter.Mock(act.VerbQuarantine))
+	env.Plat = plat.Mock(acter.Mock(act.VerbQuarantine, true))
 
 	if err := Do(env, []string{path}); err != nil {
 		t.Errorf("quarantine error: %v", err)

--- a/pkg/exec/errs.go
+++ b/pkg/exec/errs.go
@@ -1,0 +1,14 @@
+// © Roscoe Skeens <rskeens@defended.net>
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package exec
+
+import "errors"
+
+var (
+	// ErrRun means run error.
+	ErrRun = errors.New("exec: run error")
+
+	// ErrMetaChars means meta chars detected.
+	ErrMetaChars = errors.New("exec: detected meta chars")
+)

--- a/pkg/exec/re.go
+++ b/pkg/exec/re.go
@@ -1,0 +1,11 @@
+// © Roscoe Skeens <rskeens@defended.net>
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package exec
+
+import "regexp"
+
+var (
+	// reMetaChars validates shell proc args against unsafe meta chars.
+	reMetaChars = regexp.MustCompile(`[;&|$\\(\\)<>]`)
+)

--- a/pkg/exec/re_test.go
+++ b/pkg/exec/re_test.go
@@ -1,0 +1,92 @@
+// © Roscoe Skeens <rskeens@defended.net>
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package exec
+
+import (
+	"testing"
+)
+
+func TestReMetaChars(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  bool
+	}{
+		{
+			name:  "valid",
+			input: "malwatch123",
+			want:  false,
+		},
+		{
+			name:  "semicolon",
+			input: "mal;watch",
+			want:  true,
+		},
+		{
+			name:  "amp",
+			input: "mal&watch",
+			want:  true,
+		},
+		{
+			name:  "pipe",
+			input: "mal|watch",
+			want:  true,
+		},
+		{
+			name:  "dollar",
+			input: "mal$watch",
+			want:  true,
+		},
+		{
+			name:  "backslash",
+			input: "mal\\watch",
+			want:  true,
+		},
+		{
+			name:  "bracket-open",
+			input: "mal(watch",
+			want:  true,
+		},
+		{
+			name:  "bracket-close",
+			input: "mal)watch",
+			want:  true,
+		},
+		{
+			name:  "smaller",
+			input: "mal<watch",
+			want:  true,
+		},
+		{
+			name:  "greater",
+			input: "mal>watch",
+			want:  true,
+		},
+		{
+			name:  "empty",
+			input: "",
+			want:  false,
+		},
+		{
+			name:  "tab",
+			input: "mal\twatch",
+			want:  false,
+		},
+		{
+			name:  "mixed",
+			input: "abc!@#%^*_+-=[]{}':\",./?",
+			want:  false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := reMetaChars.MatchString(test.input)
+
+			if got != test.want {
+				t.Errorf("unexpected metachars result %v, want %v", got, test.want)
+			}
+		})
+	}
+}

--- a/pkg/exec/run.go
+++ b/pkg/exec/run.go
@@ -1,0 +1,36 @@
+// © Roscoe Skeens <rskeens@defended.net>
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package exec
+
+import (
+	"fmt"
+	"os/exec"
+	"slices"
+	"strings"
+)
+
+// Run executes given binary with given args.
+// Mainly for integrations, nothing else. Avoid this wherever possible.
+func Run(bin string, args ...string) (string, error) {
+	if slices.ContainsFunc(append(args, bin), func(input string) bool {
+		return reMetaChars.MatchString(input)
+	}) {
+		return "", ErrMetaChars
+	}
+
+	var (
+		cmd    = exec.Command(bin, args...)
+		stdout = &strings.Builder{}
+		stderr = &strings.Builder{}
+	)
+
+	cmd.Stdout = stdout
+	cmd.Stderr = stderr
+
+	if err := cmd.Run(); err != nil {
+		return stdout.String(), fmt.Errorf("%w, %v, %v, %v", ErrRun, err, "stderr", stderr.String())
+	}
+
+	return stdout.String(), nil
+}

--- a/pkg/exec/run_test.go
+++ b/pkg/exec/run_test.go
@@ -1,0 +1,173 @@
+// © Roscoe Skeens <rskeens@defended.net>
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package exec
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+type want struct {
+	out string
+	err error
+	has []string
+}
+
+func TestRun(t *testing.T) {
+	tests := []struct {
+		name string
+		bin  string
+		args []string
+		want *want
+	}{
+		{
+			name: "echo-single",
+			bin:  "echo",
+			args: []string{"malwatch"},
+
+			want: &want{
+				out: "malwatch\n",
+				err: nil,
+			},
+		},
+		{
+			name: "echo-multi",
+			bin:  "echo",
+			args: []string{
+				"mal",
+				"watch",
+			},
+
+			want: &want{
+				out: "mal watch\n",
+				err: nil,
+			},
+		},
+		{
+			name: "newline",
+			bin:  "echo",
+
+			want: &want{
+				out: "\n",
+				err: nil,
+			},
+		},
+		{
+			name: "empty-stdout",
+			bin:  "true",
+
+			want: &want{
+				err: nil,
+			},
+		},
+		{
+			name: "quotes",
+			bin:  "sh",
+			args: []string{
+				"-c",
+				"echo 'spaced args'",
+			},
+
+			want: &want{
+				out: "spaced args\n",
+				err: nil,
+			},
+		},
+		{
+			name: "status-code",
+			bin:  "sh",
+			args: []string{
+				"-c",
+				"exit 0",
+			},
+
+			want: &want{
+				err: nil,
+			},
+		},
+		{
+			name: "status-code-err",
+			bin:  "sh",
+			args: []string{
+				"-c",
+				"exit 1",
+			},
+
+			want: &want{
+				err: ErrRun,
+				has: []string{
+					"exit status 1",
+				},
+			},
+		},
+		{
+			name: "metachars-bin",
+			bin:  "echo;",
+			args: []string{
+				"hello",
+			},
+
+			want: &want{
+				err: ErrMetaChars,
+			},
+		},
+		{
+			name: "metachars-args",
+			bin:  "echo",
+			args: []string{
+				`insecure | args`,
+			},
+
+			want: &want{
+				err: ErrMetaChars,
+			},
+		},
+		{
+			name: "not-found",
+			bin:  "not-found",
+
+			want: &want{
+				err: ErrRun,
+				has: []string{
+					"executable file not found",
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			out, err := Run(test.bin, test.args...)
+
+			if test.want.err != nil {
+				if err == nil {
+					t.Fatalf("expected run error %v, got nil", test.want.err.Error())
+					return
+				}
+
+				if !errors.Is(err, test.want.err) {
+					t.Fatalf("unexpected run error %T %v, got %v", err, err, test.want.err)
+				}
+
+				for _, substr := range test.want.has {
+					if !strings.Contains(err.Error(), substr) {
+						t.Fatalf("missing substring for run error %v %v", err.Error(), substr)
+					}
+				}
+
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("run error: %v", err)
+				return
+			}
+
+			if out != test.want.out {
+				t.Errorf("unexpected run output %v, got %v", out, test.want.out)
+			}
+		})
+	}
+}

--- a/pkg/plat/acter/acter.go
+++ b/pkg/plat/acter/acter.go
@@ -17,7 +17,7 @@ type Acter interface {
 }
 
 // Load loads given acters filtering on enabled.
-func Load(acters []Acter) error {
+func Load(acters []Acter) ([]Acter, error) {
 	enabled := []Acter{}
 
 	for _, acter := range acters {
@@ -28,15 +28,13 @@ func Load(acters []Acter) error {
 			continue
 
 		case err != nil:
-			return err
+			return nil, err
 		}
 
 		enabled = append(enabled, acter)
 	}
 
-	acters = enabled
-
-	return nil
+	return enabled, nil
 }
 
 // Get returns a verb's acter.

--- a/pkg/plat/acter/acter.go
+++ b/pkg/plat/acter/acter.go
@@ -4,6 +4,8 @@
 package acter
 
 import (
+	"errors"
+
 	"github.com/defended-net/malwatch/pkg/scan/state"
 )
 
@@ -12,6 +14,29 @@ type Acter interface {
 	Load() error
 	Verb() string
 	Act(*state.Result) error
+}
+
+// Load loads given acters filtering on enabled.
+func Load(acters []Acter) error {
+	enabled := []Acter{}
+
+	for _, acter := range acters {
+		err := acter.Load()
+
+		switch {
+		case errors.Is(err, ErrDisabled):
+			continue
+
+		case err != nil:
+			return err
+		}
+
+		enabled = append(enabled, acter)
+	}
+
+	acters = enabled
+
+	return nil
 }
 
 // Get returns a verb's acter.

--- a/pkg/plat/acter/acter_test.go
+++ b/pkg/plat/acter/acter_test.go
@@ -11,28 +11,6 @@ import (
 	"github.com/defended-net/malwatch/pkg/scan/state"
 )
 
-func TestLoad(t *testing.T) {
-	var (
-		input = []Acter{
-			Mock(t.Name(), true),
-			Mock(t.Name()+"-disabled", false),
-		}
-
-		want = []Acter{
-			input[0],
-		}
-	)
-
-	got, err := Load(input)
-	if err != nil {
-		t.Fatalf("load error: %s", err)
-	}
-
-	if !reflect.DeepEqual(got, want) {
-		t.Errorf("unexpected load result %v, want %v", got, want)
-	}
-}
-
 func TestGet(t *testing.T) {
 	var (
 		input = t.Name()

--- a/pkg/plat/acter/acter_test.go
+++ b/pkg/plat/acter/acter_test.go
@@ -11,10 +11,32 @@ import (
 	"github.com/defended-net/malwatch/pkg/scan/state"
 )
 
+func TestLoad(t *testing.T) {
+	var (
+		input = []Acter{
+			Mock(t.Name(), true),
+			Mock(t.Name()+"-disabled", false),
+		}
+
+		want = []Acter{
+			input[0],
+		}
+	)
+
+	got, err := Load(input)
+	if err != nil {
+		t.Fatalf("load error: %s", err)
+	}
+
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("unexpected load result %v, want %v", got, want)
+	}
+}
+
 func TestGet(t *testing.T) {
 	var (
 		input = t.Name()
-		want  = Mock(t.Name())
+		want  = Mock(t.Name(), true)
 	)
 
 	got, err := Get([]Acter{want}, input)
@@ -34,7 +56,7 @@ func TestGetNoActer(t *testing.T) {
 }
 
 func TestDo(t *testing.T) {
-	input := []Acter{Mock(t.Name())}
+	input := []Acter{Mock(t.Name(), true)}
 
 	if err := Do(input, t.Name(), state.NewResult("fs", state.Paths{})); err != nil {
 		t.Errorf("do error: %s", err)
@@ -43,7 +65,7 @@ func TestDo(t *testing.T) {
 
 func TestDoNoActer(t *testing.T) {
 	var (
-		input = []Acter{Mock(t.Name())}
+		input = []Acter{Mock(t.Name(), true)}
 		want  = ErrVerbUnknown
 	)
 

--- a/pkg/plat/acter/acter_test.go
+++ b/pkg/plat/acter/acter_test.go
@@ -11,6 +11,28 @@ import (
 	"github.com/defended-net/malwatch/pkg/scan/state"
 )
 
+func TestLoad(t *testing.T) {
+	var (
+		input = []Acter{
+			Mock(t.Name(), true),
+			Mock(t.Name()+"-disabled", false),
+		}
+
+		want = []Acter{
+			input[0],
+		}
+	)
+
+	got, err := Load(input)
+	if err != nil {
+		t.Fatalf("load error: %s", err)
+	}
+
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("unexpected load result %v, want %v", got, want)
+	}
+}
+
 func TestGet(t *testing.T) {
 	var (
 		input = t.Name()

--- a/pkg/plat/acter/errs.go
+++ b/pkg/plat/acter/errs.go
@@ -10,5 +10,5 @@ var (
 	ErrDisabled = errors.New("acter: disabled")
 
 	// ErrVerbUnknown means verb is unknown.
-	ErrVerbUnknown = errors.New("act: unknown verb")
+	ErrVerbUnknown = errors.New("acter: unknown verb")
 )

--- a/pkg/plat/acter/errs.go
+++ b/pkg/plat/acter/errs.go
@@ -6,6 +6,9 @@ package acter
 import "errors"
 
 var (
+	// ErrDisabled means disabled.
+	ErrDisabled = errors.New("acter: disabled")
+
 	// ErrVerbUnknown means verb is unknown.
 	ErrVerbUnknown = errors.New("act: unknown verb")
 )

--- a/pkg/plat/acter/mock.go
+++ b/pkg/plat/acter/mock.go
@@ -8,14 +8,16 @@ import (
 )
 
 type mock struct {
-	verb  string
-	Acted bool
+	verb      string
+	isEnabled bool
+	Acted     bool
 }
 
 // Mock mocks an acter.
-func Mock(verb string) Acter {
+func Mock(verb string, enabled bool) Acter {
 	return &mock{
-		verb: verb,
+		verb:      verb,
+		isEnabled: enabled,
 	}
 }
 
@@ -26,6 +28,10 @@ func (act *mock) Verb() string {
 
 // Load loads the quarantiner.
 func (act *mock) Load() error {
+	if !act.isEnabled {
+		return ErrDisabled
+	}
+
 	return nil
 }
 

--- a/pkg/plat/acter/mock_test.go
+++ b/pkg/plat/acter/mock_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/defended-net/malwatch/pkg/scan/state"
 )
 
-func TestLoad(t *testing.T) {
+func TestMockLoad(t *testing.T) {
 	input := &mock{
 		isEnabled: true,
 	}

--- a/pkg/plat/acter/mock_test.go
+++ b/pkg/plat/acter/mock_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/defended-net/malwatch/pkg/scan/state"
 )
 
-func TestMockLoad(t *testing.T) {
+func TestLoad(t *testing.T) {
 	input := &mock{
 		isEnabled: true,
 	}

--- a/pkg/plat/acter/mock_test.go
+++ b/pkg/plat/acter/mock_test.go
@@ -10,8 +10,10 @@ import (
 	"github.com/defended-net/malwatch/pkg/scan/state"
 )
 
-func TestLoad(t *testing.T) {
-	input := &mock{}
+func TestMockLoad(t *testing.T) {
+	input := &mock{
+		isEnabled: true,
+	}
 
 	if got := input.Load(); got != nil {
 		t.Errorf("unexpected verb result %v, want %v", got, nil)
@@ -46,10 +48,11 @@ func TestMock(t *testing.T) {
 	var (
 		input = t.Name()
 
-		got = Mock(input)
+		got = Mock(input, true)
 
 		want = &mock{
-			verb: input,
+			verb:      input,
+			isEnabled: true,
 		}
 	)
 

--- a/pkg/plat/cpanel/cfg_test.go
+++ b/pkg/plat/cpanel/cfg_test.go
@@ -6,33 +6,30 @@ package cpanel
 import (
 	"os"
 	"path/filepath"
-	"reflect"
 	"testing"
 )
 
 func TestCfgLoad(t *testing.T) {
-	path := filepath.Join(t.TempDir(), t.Name())
+	var (
+		path = filepath.Join(t.TempDir(), t.Name())
+
+		input = &Cfg{
+			path: path,
+		}
+	)
 
 	if _, err := os.Create(path); err != nil {
 		t.Fatalf("file create error: %v", err)
 	}
 
-	var (
-		input = &Cfg{
-			path: path,
-		}
-
-		got = input.Load()
-	)
-
-	if !reflect.DeepEqual(got, nil) {
-		t.Errorf("unexpected cfg load result %v, want %v", got, nil)
+	if err := input.Load(); err != nil {
+		t.Errorf("cfg load error: %v", err)
 	}
 }
 
 func TestCfgPath(t *testing.T) {
 	var (
-		want = filepath.Join(t.TempDir(), t.Name())
+		want = t.Name()
 
 		plat = &Plat{
 			cfg: &Cfg{
@@ -43,7 +40,7 @@ func TestCfgPath(t *testing.T) {
 		got = plat.cfg.Path()
 	)
 
-	if !reflect.DeepEqual(got, want) {
-		t.Errorf("unexpected cfg result %v, want %v", got, want)
+	if got != want {
+		t.Errorf("unexpected cfg path %v, want %v", got, want)
 	}
 }

--- a/pkg/plat/cpanel/cpanel.go
+++ b/pkg/plat/cpanel/cpanel.go
@@ -4,15 +4,14 @@
 package cpanel
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
-	"os/exec"
 	"path/filepath"
 	"slices"
 
 	"github.com/defended-net/malwatch/pkg/boot/env"
 	"github.com/defended-net/malwatch/pkg/boot/env/re"
+	"github.com/defended-net/malwatch/pkg/exec"
 	"github.com/defended-net/malwatch/pkg/plat"
 	"github.com/defended-net/malwatch/pkg/plat/acter"
 	"github.com/defended-net/malwatch/pkg/plat/preset/act"
@@ -128,7 +127,7 @@ func (plat *Plat) Load() error {
 	return nil
 }
 
-// GetDocRoots performs a get_domain_info request and returns document root paths.
+// GetDocRoots performs a get_domain_info request and returns docroot paths.
 func (plat *Plat) GetDocRoots() ([]string, error) {
 	var (
 		info  = &DomainInfo{}
@@ -141,12 +140,12 @@ func (plat *Plat) GetDocRoots() ([]string, error) {
 		args = plat.domainInfo
 	}
 
-	resp, err := plat.Exec(args...)
+	resp, err := exec.Run(plat.bin, args...)
 	if err != nil {
 		return nil, err
 	}
 
-	if err := json.Unmarshal(resp, info); err != nil {
+	if err := json.Unmarshal([]byte(resp), info); err != nil {
 		return nil, fmt.Errorf("%w, %v", ErrAPIDomInfoUnmarshal, err)
 	}
 
@@ -157,20 +156,6 @@ func (plat *Plat) GetDocRoots() ([]string, error) {
 	return paths, nil
 }
 
-// Exec performs an api lookup using whmapi cmd.
-func (plat *Plat) Exec(args ...string) ([]byte, error) {
-	buff := bytes.Buffer{}
-
-	cmd := exec.Command(plat.bin, args...)
-	cmd.Stdout = &buff
-
-	if err := cmd.Run(); err != nil {
-		return nil, fmt.Errorf("%w, %v", ErrAPIToolExec, err)
-	}
-
-	return buff.Bytes(), nil
-}
-
 // Acters returns a given cpanel plat's active acts.
 func (plat *Plat) Acters() []acter.Acter {
 	return plat.acters
@@ -179,4 +164,91 @@ func (plat *Plat) Acters() []acter.Acter {
 // Cfg returns a given cpanel plat's cfg.
 func (plat *Plat) Cfg() plat.Cfg {
 	return plat.cfg
+}
+
+// Mock mocks a plat.
+func Mock(name string, dir string) (*Plat, error) {
+	env, err := env.Mock(name, dir)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Plat{
+		env: env,
+
+		acters: []acter.Acter{
+			acter.Mock(name),
+		},
+
+		cfg: &Cfg{
+			path: filepath.Join(env.Paths.Plat.Dir, "directadmin.toml"),
+		},
+
+		bin: "echo",
+
+		domainInfo: []string{`{
+    "data": {
+        "domains": [
+            {
+                "ipv4": "123.123.123.123",
+                "modsecurity_enabled": 1,
+                "php_version": "ea-php81",
+                "user_owner": "first",
+                "user": "first",
+                "domain_type": "main",
+                "ipv6": null,
+                "port": "80",
+                "port_ssl": "443",
+                "ipv6_is_dedicated": 0,
+                "domain": "first.com",
+                "parent_domain": "one.example",
+                "docroot": "/home/one/public_html",
+                "ipv4_ssl": "123.123.123.123"
+            },
+
+            {
+                "ipv6": null,
+                "port": "80",
+                "php_version": "ea-php81",
+                "modsecurity_enabled": 1,
+                "ipv4": "123.123.123.123",
+                "user": "second",
+                "domain_type": "main",
+                "user_owner": "second",
+                "ipv4_ssl": "123.123.123.123",
+                "docroot": "/home/two/public_html",
+                "parent_domain": "two.example",
+                "port_ssl": "443",
+                "domain": "second.com",
+                "ipv6_is_dedicated": 0
+            },
+
+            {
+                "ipv4": "123.123.123.123",
+                "modsecurity_enabled": 1,
+                "php_version": "ea-php81",
+                "user_owner": "third",
+                "user": "third",
+                "domain_type": "main",
+                "ipv6": null,
+                "port": "80",
+                "port_ssl": "443",
+                "ipv6_is_dedicated": 0,
+                "domain": "third.com",
+                "parent_domain": "three.example",
+                "docroot": "/home/three/public_html",
+                "ipv4_ssl": "123.123.123.123"
+            }
+        ]
+    },
+    
+    "metadata": {
+        "result": 1,
+        "version": 1,
+        "reason": "OK",
+        "command": "get_domain_info"
+    }
+}`,
+		},
+	}, nil
 }

--- a/pkg/plat/cpanel/cpanel.go
+++ b/pkg/plat/cpanel/cpanel.go
@@ -83,17 +83,14 @@ func New(env *env.Env) *Plat {
 	}
 }
 
-// Load reads given plat cfg files.
+// Load reads given plat's cfgs.
 func (plat *Plat) Load() error {
-	enabled := []acter.Acter{}
-
-	for _, acter := range plat.acters {
-		if err := acter.Load(); err == nil {
-			enabled = append(enabled, acter)
-		}
+	acters, err := acter.Load(plat.acters)
+	if err != nil {
+		return err
 	}
 
-	plat.acters = enabled
+	plat.acters = acters
 
 	re.SetTargets(reTarget)
 
@@ -170,7 +167,7 @@ func Mock(name string, dir string) (*Plat, error) {
 		env: env,
 
 		acters: []acter.Acter{
-			acter.Mock(name),
+			acter.Mock(name, true),
 		},
 
 		cfg: &Cfg{

--- a/pkg/plat/cpanel/cpanel.go
+++ b/pkg/plat/cpanel/cpanel.go
@@ -69,18 +69,11 @@ type Meta struct {
 // New returns a plat from given env.
 func New(env *env.Env) *Plat {
 	return &Plat{
-		env: env,
-
-		acters: []acter.Acter{
-			act.NewExiler(env),
-			act.NewQuarantiner(env),
-			act.NewCleaner(env),
-			act.NewAlerter(env),
-		},
+		env:    env,
+		acters: act.Preset(env),
 
 		cfg: &Cfg{
-			path:     filepath.Join(env.Paths.Plat.Dir, "cpanel.toml"),
-			SkipAccs: []string{""},
+			path: filepath.Join(env.Paths.Plat.Dir, "cpanel.toml"),
 		},
 
 		// Path to whmapi. Must be absolute for CL compat https://api.docs.cpanel.net/whm/introduction

--- a/pkg/plat/cpanel/cpanel_test.go
+++ b/pkg/plat/cpanel/cpanel_test.go
@@ -97,7 +97,7 @@ func TestCfg(t *testing.T) {
 
 func TestActers(t *testing.T) {
 	var (
-		input = acter.Mock(act.VerbAlert)
+		input = acter.Mock(act.VerbAlert, true)
 
 		plat = &Plat{
 			acters: []acter.Acter{

--- a/pkg/plat/directadmin/cfg.go
+++ b/pkg/plat/directadmin/cfg.go
@@ -1,0 +1,33 @@
+// © Roscoe Skeens <rskeens@defended.net>
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package directadmin
+
+import (
+	"github.com/defended-net/malwatch/pkg/fsys"
+)
+
+// Cfg represents the cfg.
+type Cfg struct {
+	path     string
+	User     string
+	SkipAccs []string
+}
+
+// Load loads the cfg.
+func (cfg *Cfg) Load() error {
+	if err := fsys.ReadTOML(cfg.Path(), cfg); err != nil {
+		return err
+	}
+
+	if cfg.User == "" {
+		cfg.User = "admin"
+	}
+
+	return nil
+}
+
+// Path returns a given cfg's toml path.
+func (cfg *Cfg) Path() string {
+	return cfg.path
+}

--- a/pkg/plat/directadmin/cfg_test.go
+++ b/pkg/plat/directadmin/cfg_test.go
@@ -1,0 +1,84 @@
+// © Roscoe Skeens <rskeens@defended.net>
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package directadmin
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+func TestCfgLoad(t *testing.T) {
+	path := filepath.Join(t.TempDir(), t.Name())
+
+	if _, err := os.Create(path); err != nil {
+		t.Fatalf("file create error: %v", err)
+	}
+
+	var (
+		got = &Cfg{
+			path: path,
+		}
+
+		want = &Cfg{
+			path: path,
+			User: "admin",
+		}
+	)
+
+	if err := got.Load(); err != nil {
+		t.Fatalf("cfg load error: %v", err)
+	}
+
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("unexpected cfg load result %v, want %v", got, nil)
+	}
+}
+
+func TestCfgLoadCustomUser(t *testing.T) {
+	path := filepath.Join(t.TempDir(), t.Name())
+
+	if _, err := os.Create(path); err != nil {
+		t.Fatalf("file create error: %v", err)
+	}
+
+	var (
+		got = &Cfg{
+			path: path,
+			User: t.Name(),
+		}
+
+		want = &Cfg{
+			path: path,
+			User: t.Name(),
+		}
+	)
+
+	if err := got.Load(); err != nil {
+		t.Fatalf("cfg load error: %v", err)
+	}
+
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("unexpected cfg load result %v, want %v", got, nil)
+	}
+}
+
+func TestCfgPath(t *testing.T) {
+	var (
+		want = filepath.Join(t.TempDir(), t.Name())
+
+		plat = &Plat{
+			cfg: &Cfg{
+				path: want,
+			},
+		}
+
+		got = plat.cfg.Path()
+	)
+
+	if got != want {
+		t.Errorf("unexpected cfg path result %v, want %v", got, want)
+	}
+}

--- a/pkg/plat/directadmin/directadmin.go
+++ b/pkg/plat/directadmin/directadmin.go
@@ -1,0 +1,260 @@
+// © Roscoe Skeens <rskeens@defended.net>
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package directadmin
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"path/filepath"
+	"slices"
+	"strings"
+
+	"github.com/defended-net/malwatch/pkg/boot/env"
+	"github.com/defended-net/malwatch/pkg/boot/env/re"
+	"github.com/defended-net/malwatch/pkg/exec"
+	"github.com/defended-net/malwatch/pkg/fsys"
+	"github.com/defended-net/malwatch/pkg/plat"
+	"github.com/defended-net/malwatch/pkg/plat/acter"
+	"github.com/defended-net/malwatch/pkg/plat/preset/act"
+)
+
+// Plat represents a directadmin platform.
+type Plat struct {
+	env       *env.Env
+	cfg       *Cfg
+	acters    []acter.Acter
+	bin       string
+	url       string
+	endpoints *endpoints
+}
+
+// Info represents top level api response.
+type Info struct {
+	Users map[string]users
+}
+
+// users represents user:domains.
+type users map[string]domains
+
+// domains represents domain:docroots.
+type domains map[string]*docroot
+
+type docroot struct {
+	PrivateHTML string  `json:"private_html"`
+	PublicHTML  string  `json:"public_html"`
+	Subdomains  domains `json:"subdomains"`
+}
+
+type endpoints struct {
+	docroots *endpoint
+}
+
+type endpoint struct {
+	url    string
+	base   string
+	params map[string]string
+}
+
+// New returns a plat from given env.
+func New(env *env.Env) *Plat {
+	return &Plat{
+		env:    env,
+		acters: act.Preset(env),
+
+		cfg: &Cfg{
+			path: filepath.Join(env.Paths.Plat.Dir, "directadmin.toml"),
+		},
+
+		// https://docs.directadmin.com/directadmin/general-usage/directadmin-binary.html
+		bin: "/usr/local/directadmin/directadmin",
+
+		endpoints: &endpoints{
+			docroots: &endpoint{
+				base: "/CMD_API_DOMAIN",
+
+				params: map[string]string{
+					"action": "document_root_all",
+				},
+			},
+		},
+	}
+}
+
+// Load reads given plat's cfgs.
+func (plat *Plat) Load() error {
+	if err := plat.Auth(plat.cfg.User); err != nil {
+		return err
+	}
+
+	acters, err := acter.Load(plat.acters)
+	if err != nil {
+		return err
+	}
+
+	plat.acters = acters
+
+	for _, endpoint := range []*endpoint{
+		plat.endpoints.docroots,
+	} {
+		if err := endpoint.Prep(plat.url); err != nil {
+			return err
+		}
+	}
+
+	re.SetTargets(reTarget)
+
+	tmps := []string{
+		"/tmp",
+		"/var/tmp",
+		"/dev/shm",
+	}
+
+	paths, err := plat.DocRoots()
+	if err != nil {
+		return err
+	}
+
+	for _, path := range append(paths, tmps...) {
+		if !slices.Contains(plat.cfg.SkipAccs, re.Target(path)) &&
+			!slices.Contains(plat.env.Cfg.Scans.Paths, path) {
+			plat.env.Cfg.Scans.Paths = append(plat.env.Cfg.Scans.Paths, path)
+		}
+	}
+
+	return nil
+}
+
+// DocRoots performs a get_domain_info req and returns document root paths.
+func (plat *Plat) DocRoots() ([]string, error) {
+	var (
+		info  = &Info{}
+		dedup = map[string]struct{}{}
+		paths []string
+	)
+
+	resp, err := http.Get(plat.endpoints.docroots.url)
+	if err != nil {
+		return nil, err
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := json.Unmarshal(body, info); err != nil {
+		return nil, fmt.Errorf("%w, %v", ErrAPIDomInfoUnmarshal, err)
+	}
+
+	for _, domains := range info.Users {
+		for _, metas := range domains {
+			for _, meta := range metas {
+				dedup[filepath.Join(filepath.Dir(meta.PublicHTML), "tmp")] = struct{}{}
+
+				dedup[meta.PublicHTML] = struct{}{}
+				dedup[meta.PrivateHTML] = struct{}{}
+
+				for _, subdomain := range meta.Subdomains {
+					if fsys.IsRel(subdomain.PublicHTML, meta.PublicHTML) {
+						continue
+					}
+
+					// private_html has same base dir so can bundle together.
+					dedup[subdomain.PublicHTML] = struct{}{}
+					dedup[subdomain.PrivateHTML] = struct{}{}
+				}
+			}
+		}
+	}
+
+	for path := range dedup {
+		if path != "" {
+			paths = append(paths, path)
+		}
+	}
+
+	slices.Sort(paths)
+
+	return paths, nil
+}
+
+// Auth auths for given user.
+func (plat *Plat) Auth(user string) error {
+	if plat.url != "" {
+		return nil
+	}
+
+	url, err := exec.Run(plat.bin, "root-auth-url", fmt.Sprintf("--user=%s", user))
+	if err != nil {
+		return fmt.Errorf("%w, %v", ErrAPIExec, err)
+	}
+
+	plat.url = strings.TrimSuffix(string(url), "\n")
+
+	return nil
+}
+
+// Prep prepares given api endpoint by appending the base followed by adding params.
+// Encoded url is then stored.
+func (endpoint *endpoint) Prep(authURL string) error {
+	path, err := url.JoinPath(authURL, endpoint.base)
+	if err != nil {
+		return err
+	}
+
+	params := url.Values{}
+
+	for name, val := range endpoint.params {
+		params.Add(name, val)
+	}
+
+	endpoint.url = path + "?" + params.Encode()
+
+	return nil
+}
+
+// Acters returns given plat's enabled acts.
+func (plat *Plat) Acters() []acter.Acter {
+	return plat.acters
+}
+
+// Cfg returns given plat's cfg.
+func (plat *Plat) Cfg() plat.Cfg {
+	return plat.cfg
+}
+
+// Mock mocks a plat.
+func Mock(name string, dir string) (*Plat, error) {
+	env, err := env.Mock(name, dir)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Plat{
+		env: env,
+
+		acters: []acter.Acter{
+			acter.Mock(name, true),
+		},
+
+		cfg: &Cfg{
+			path: filepath.Join(env.Paths.Plat.Dir, "directadmin.toml"),
+		},
+
+		bin: "echo",
+
+		endpoints: &endpoints{
+			docroots: &endpoint{
+				base: "/CMD_API_DOMAIN",
+
+				params: map[string]string{
+					"action": "document_root_all",
+				},
+			},
+		},
+	}, nil
+}

--- a/pkg/plat/directadmin/directadmin_test.go
+++ b/pkg/plat/directadmin/directadmin_test.go
@@ -1,0 +1,367 @@
+// © Roscoe Skeens <rskeens@defended.net>
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package directadmin
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"reflect"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/defended-net/malwatch/pkg/boot/env"
+	"github.com/defended-net/malwatch/pkg/plat/acter"
+	"github.com/defended-net/malwatch/pkg/plat/preset/act"
+)
+
+func TestNew(t *testing.T) {
+	env, err := env.Mock(t.Name(), t.TempDir())
+	if err != nil {
+		t.Errorf("env mock error: %v", err)
+	}
+
+	var (
+		want = &Plat{
+			env: env,
+
+			acters: act.Preset(env),
+
+			cfg: &Cfg{
+				path: filepath.Join(env.Paths.Plat.Dir, "directadmin.toml"),
+			},
+
+			// https://docs.directadmin.com/directadmin/general-usage/directadmin-binary.html
+			bin: "/usr/local/directadmin/directadmin",
+
+			endpoints: &endpoints{
+				docroots: &endpoint{
+					base: "/CMD_API_DOMAIN",
+
+					params: map[string]string{
+						"action": "document_root_all",
+					},
+				},
+			},
+		}
+
+		got = New(env)
+	)
+
+	if !reflect.DeepEqual(got.cfg, want.cfg) {
+		t.Errorf("unexpected cfg %v, want %v", got, want)
+	}
+
+	if !reflect.DeepEqual(got.endpoints, want.endpoints) {
+		t.Errorf("unexpected endpoints %v, want %v", got, want)
+	}
+}
+
+func TestLoad(t *testing.T) {
+	plat, err := Mock(t.Name(), t.TempDir())
+	if err != nil {
+		t.Errorf("mock error: %v", err)
+	}
+
+	serve := httptest.NewServer(http.HandlerFunc(func(wr http.ResponseWriter, _ *http.Request) {
+		data := Info{
+			Users: map[string]users{
+				"one": {
+					"one": domains{
+						"one.example": &docroot{
+							PublicHTML:  "/home/one/domains/one.example/public_html",
+							PrivateHTML: "/home/one/domains/one.example/private_html",
+
+							Subdomains: domains{},
+						},
+					},
+				},
+			},
+		}
+
+		json.NewEncoder(wr).Encode(data)
+	}))
+
+	plat.url = serve.URL
+
+	if err = plat.Load(); err != nil {
+		t.Errorf("load error: %v", err)
+	}
+}
+
+func TestLoadAuthed(t *testing.T) {
+	plat, err := Mock(t.Name(), t.TempDir())
+	if err != nil {
+		t.Errorf("mock error: %v", err)
+	}
+
+	if err = plat.Load(); err != nil && !strings.Contains(err.Error(), "unsupported protocol scheme") {
+		t.Errorf("load error: %v", err)
+	}
+}
+
+func TestDocRoots(t *testing.T) {
+	tests := []struct {
+		name  string
+		serve *httptest.Server
+		want  []string
+	}{
+
+		{
+			name: "single-user-single-dom",
+
+			serve: httptest.NewServer(http.HandlerFunc(func(wr http.ResponseWriter, _ *http.Request) {
+				data := Info{
+					Users: map[string]users{
+						"one": {
+							"one": domains{
+								"one.example": &docroot{
+									PublicHTML:  "/home/one/domains/one.example/public_html",
+									PrivateHTML: "/home/one/domains/one.example/private_html",
+								},
+							},
+						},
+					},
+				}
+
+				json.NewEncoder(wr).Encode(data)
+			})),
+
+			want: []string{
+				"/home/one/domains/one.example/private_html",
+				"/home/one/domains/one.example/public_html",
+				"/home/one/domains/one.example/tmp",
+			},
+		},
+
+		{
+			name: "single-user-single-sub",
+
+			serve: httptest.NewServer(http.HandlerFunc(func(wr http.ResponseWriter, _ *http.Request) {
+				data := Info{
+					Users: map[string]users{
+						"one": {
+							"one": domains{
+								"one.example": &docroot{
+									PublicHTML:  "/home/one/domains/one.example/public_html",
+									PrivateHTML: "/home/one/domains/one.example/private_html",
+
+									Subdomains: domains{
+										"sub-1.domain1.com": &docroot{
+											PublicHTML:  "/home/one/domains/one.example/sub-one/public_html",
+											PrivateHTML: "/home/one/domains/one.example/sub-one/private_html",
+
+											Subdomains: domains{},
+										},
+									},
+								},
+							},
+						},
+					},
+				}
+
+				json.NewEncoder(wr).Encode(data)
+			})),
+
+			want: []string{
+				"/home/one/domains/one.example/private_html",
+				"/home/one/domains/one.example/public_html",
+				"/home/one/domains/one.example/sub-one/private_html",
+				"/home/one/domains/one.example/sub-one/public_html",
+				"/home/one/domains/one.example/tmp",
+			},
+		},
+
+		{
+			name: "single-user-multi-dom",
+
+			serve: httptest.NewServer(http.HandlerFunc(func(wr http.ResponseWriter, _ *http.Request) {
+				data := Info{
+					Users: map[string]users{
+						"one": {
+							"one": domains{
+								"one.example": &docroot{
+									PublicHTML:  "/home/one/domains/one.example/public_html",
+									PrivateHTML: "/home/one/domains/one.example/private_html",
+
+									Subdomains: domains{},
+								},
+
+								"two.example": &docroot{
+									PublicHTML:  "/home/one/domains/two.example/public_html",
+									PrivateHTML: "/home/one/domains/two.example/private_html",
+
+									Subdomains: domains{},
+								},
+							},
+						},
+					},
+				}
+
+				json.NewEncoder(wr).Encode(data)
+			})),
+
+			want: []string{
+				"/home/one/domains/one.example/private_html",
+				"/home/one/domains/one.example/public_html",
+				"/home/one/domains/one.example/tmp",
+
+				"/home/one/domains/two.example/private_html",
+				"/home/one/domains/two.example/public_html",
+				"/home/one/domains/two.example/tmp",
+			},
+		},
+
+		{
+			name: "multi-user-multi-dom",
+
+			serve: httptest.NewServer(http.HandlerFunc(func(wr http.ResponseWriter, _ *http.Request) {
+				data := Info{
+					Users: map[string]users{
+						"one": {
+							"one": domains{
+								"one.example": &docroot{
+									PublicHTML:  "/home/one/domains/one.example/public_html",
+									PrivateHTML: "/home/one/domains/one.example/private_html",
+
+									Subdomains: domains{
+										"sub-one.example": &docroot{
+											PublicHTML:  "/home/one/domains/one.example/sub-one/public_html",
+											PrivateHTML: "/home/one/domains/one.example/sub-one/private_html",
+
+											Subdomains: domains{},
+										},
+
+										"sub-two.example": &docroot{
+											PublicHTML:  "/home/one/domains/one.example/sub-two/public_html",
+											PrivateHTML: "/home/one/domains/one.example/sub-two/private_html",
+
+											Subdomains: domains{},
+										},
+									},
+								},
+
+								"two.example": &docroot{
+									PublicHTML:  "/home/one/domains/two.example/public_html",
+									PrivateHTML: "/home/one/domains/two.example/private_html",
+
+									Subdomains: domains{},
+								},
+							},
+						},
+
+						"two": {
+							"two": domains{
+								"three.example": &docroot{
+									PublicHTML:  "/home/two/domains/three.example/public_html",
+									PrivateHTML: "/home/two/domains/three.example/private_html",
+
+									Subdomains: domains{},
+								},
+
+								"four.example": &docroot{
+									PublicHTML:  "/home/two/domains/four.example/public_html",
+									PrivateHTML: "/home/two/domains/four.example/private_html",
+
+									Subdomains: domains{},
+								},
+							},
+						},
+					},
+				}
+
+				json.NewEncoder(wr).Encode(data)
+			})),
+
+			want: []string{
+				"/home/one/domains/one.example/private_html",
+				"/home/one/domains/one.example/public_html",
+				"/home/one/domains/one.example/sub-one/private_html",
+				"/home/one/domains/one.example/sub-one/public_html",
+				"/home/one/domains/one.example/sub-two/private_html",
+				"/home/one/domains/one.example/sub-two/public_html",
+				"/home/one/domains/one.example/tmp",
+
+				"/home/one/domains/two.example/private_html",
+				"/home/one/domains/two.example/public_html",
+				"/home/one/domains/two.example/tmp",
+
+				"/home/two/domains/four.example/private_html",
+				"/home/two/domains/four.example/public_html",
+				"/home/two/domains/four.example/tmp",
+
+				"/home/two/domains/three.example/private_html",
+				"/home/two/domains/three.example/public_html",
+				"/home/two/domains/three.example/tmp",
+			},
+		},
+		{
+			name: "empty",
+
+			serve: httptest.NewServer(http.HandlerFunc(func(wr http.ResponseWriter, _ *http.Request) {
+				data := Info{Users: map[string]users{}}
+				json.NewEncoder(wr).Encode(data)
+			})),
+
+			want: []string{},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			plat := &Plat{
+				endpoints: &endpoints{
+					docroots: &endpoint{
+						url: test.serve.URL,
+					},
+				},
+			}
+
+			paths, err := plat.DocRoots()
+			if err != nil {
+				t.Errorf("docroots error: %v", err)
+			}
+
+			if !slices.Equal(paths, test.want) {
+				t.Errorf("expected paths %v, got %v", test.want, paths)
+			}
+		})
+	}
+}
+
+func TestCfg(t *testing.T) {
+	var (
+		plat = &Plat{
+			cfg: &Cfg{
+				User: t.Name(),
+			},
+		}
+
+		got = plat.Cfg()
+	)
+
+	if !reflect.DeepEqual(got, plat.cfg) {
+		t.Errorf("unexpected cfg result %v, want %v", got, plat.cfg)
+	}
+}
+
+func TestActers(t *testing.T) {
+	var (
+		input = acter.Mock(act.VerbAlert, true)
+
+		plat = &Plat{
+			acters: []acter.Acter{
+				input,
+			},
+		}
+
+		got = plat.Acters()
+	)
+
+	if !reflect.DeepEqual(got, plat.acters) {
+		t.Errorf("unexpected acters result %v, want %v", got, plat.acters)
+	}
+}

--- a/pkg/plat/directadmin/directadmin_test.go
+++ b/pkg/plat/directadmin/directadmin_test.go
@@ -82,7 +82,9 @@ func TestLoad(t *testing.T) {
 			},
 		}
 
-		json.NewEncoder(wr).Encode(data)
+		if err := json.NewEncoder(wr).Encode(data); err != nil {
+			t.Fatalf("json marshal error: %v", err)
+		}
 	}))
 
 	plat.url = serve.URL
@@ -127,7 +129,9 @@ func TestDocRoots(t *testing.T) {
 					},
 				}
 
-				json.NewEncoder(wr).Encode(data)
+				if err := json.NewEncoder(wr).Encode(data); err != nil {
+					t.Fatalf("json marshal error: %v", err)
+				}
 			})),
 
 			want: []string{
@@ -163,7 +167,9 @@ func TestDocRoots(t *testing.T) {
 					},
 				}
 
-				json.NewEncoder(wr).Encode(data)
+				if err := json.NewEncoder(wr).Encode(data); err != nil {
+					t.Fatalf("json marshal error: %v", err)
+				}
 			})),
 
 			want: []string{
@@ -201,7 +207,9 @@ func TestDocRoots(t *testing.T) {
 					},
 				}
 
-				json.NewEncoder(wr).Encode(data)
+				if err := json.NewEncoder(wr).Encode(data); err != nil {
+					t.Fatalf("json marshal error: %v", err)
+				}
 			})),
 
 			want: []string{
@@ -273,7 +281,9 @@ func TestDocRoots(t *testing.T) {
 					},
 				}
 
-				json.NewEncoder(wr).Encode(data)
+				if err := json.NewEncoder(wr).Encode(data); err != nil {
+					t.Fatalf("json marshal error: %v", err)
+				}
 			})),
 
 			want: []string{
@@ -303,7 +313,9 @@ func TestDocRoots(t *testing.T) {
 
 			serve: httptest.NewServer(http.HandlerFunc(func(wr http.ResponseWriter, _ *http.Request) {
 				data := Info{Users: map[string]users{}}
-				json.NewEncoder(wr).Encode(data)
+				if err := json.NewEncoder(wr).Encode(data); err != nil {
+					t.Fatalf("json marshal error: %v", err)
+				}
 			})),
 
 			want: []string{},

--- a/pkg/plat/directadmin/errs.go
+++ b/pkg/plat/directadmin/errs.go
@@ -1,0 +1,14 @@
+// © Roscoe Skeens <rskeens@defended.net>
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package directadmin
+
+import "errors"
+
+var (
+	// ErrAPIExec means an api bin exec error.
+	ErrAPIExec = errors.New("directadmin: api bin exec error")
+
+	// ErrAPIDomInfoUnmarshal means an domaininfo unmarshal error.
+	ErrAPIDomInfoUnmarshal = errors.New("directadmin: domain info unmarshal error")
+)

--- a/pkg/plat/directadmin/re.go
+++ b/pkg/plat/directadmin/re.go
@@ -1,0 +1,13 @@
+// © Roscoe Skeens <rskeens@defended.net>
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package directadmin
+
+import "regexp"
+
+var (
+	// reTarget validates a system user's home dir.
+	// https://docs.directadmin.com/directadmin/backup-restore-migration/migration-to-da.html
+	// https://systemd.io/USER_NAMES/#:~:text=A%20size%20limit%20is%20enforced,ambiguity%20with%20login%20accounting)%20and
+	reTarget = regexp.MustCompile(`^/home/(?P<target>[a-z\d-]{1,31})(?:/.*)?$`)
+)

--- a/pkg/plat/directadmin/re_test.go
+++ b/pkg/plat/directadmin/re_test.go
@@ -1,0 +1,78 @@
+// © Roscoe Skeens <rskeens@defended.net>
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package directadmin
+
+import "testing"
+
+func TestTarget(t *testing.T) {
+	tests := map[string]struct {
+		input string
+		want  bool
+	}{
+		"valid": {
+			input: "/home/user",
+			want:  true,
+		},
+
+		"valid-slash": {
+			input: "/home/user/",
+			want:  true,
+		},
+
+		"valid-hyphen": {
+			input: "/home/user-name",
+			want:  true,
+		},
+
+		"max": {
+			input: "/home/user1234567890",
+			want:  true,
+		},
+
+		"exceed": {
+			input: "/home/user1234567890123456789011234567",
+			want:  false,
+		},
+
+		"special-char": {
+			input: "/home/user#",
+			want:  false,
+		},
+
+		"glob": {
+			input: "/home/user*",
+			want:  false,
+		},
+
+		"space": {
+			input: "/home/ ",
+			want:  false,
+		},
+
+		"space-slash": {
+			input: "/home/ /",
+			want:  false,
+		},
+
+		"empty": {
+			input: "/home",
+			want:  false,
+		},
+
+		"empty-slash": {
+			input: "/home/",
+			want:  false,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			result := reTarget.MatchString(test.input)
+
+			if result != test.want {
+				t.Errorf("unexpected regex result %v, want %v", result, test.want)
+			}
+		})
+	}
+}

--- a/pkg/plat/plat_test.go
+++ b/pkg/plat/plat_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestLoad(t *testing.T) {
-	mock := Mock(acter.Mock(t.Name()))
+	mock := Mock(acter.Mock(t.Name(), true))
 
 	if err := mock.Load(); err != nil {
 		t.Errorf("load error: %v", err)
@@ -32,7 +32,7 @@ func TestCfg(t *testing.T) {
 func TestMock(t *testing.T) {
 	var (
 		want = []acter.Acter{
-			acter.Mock(t.Name()),
+			acter.Mock(t.Name(), true),
 		}
 
 		got = Mock(want...)

--- a/pkg/plat/preset/act/clean.go
+++ b/pkg/plat/preset/act/clean.go
@@ -19,6 +19,7 @@ import (
 	"github.com/defended-net/malwatch/pkg/boot/env/cfg/act"
 	"github.com/defended-net/malwatch/pkg/db/orm/hit"
 	"github.com/defended-net/malwatch/pkg/fsys"
+	"github.com/defended-net/malwatch/pkg/plat/acter"
 	"github.com/defended-net/malwatch/pkg/scan/state"
 	"github.com/defended-net/malwatch/pkg/sig"
 	"github.com/defended-net/malwatch/third_party/yr"
@@ -48,7 +49,7 @@ func NewCleaner(env *env.Env) *Cleaner {
 // Load loads given cleaner.
 func (cleaner *Cleaner) Load() error {
 	if cleaner.dir == "" {
-		return ErrDisabled
+		return acter.ErrDisabled
 	}
 
 	rules, err := yr.LoadRules(cleaner.rules)

--- a/pkg/plat/preset/act/errs.go
+++ b/pkg/plat/preset/act/errs.go
@@ -6,9 +6,6 @@ package act
 import "errors"
 
 var (
-	// ErrDisabled means disabled.
-	ErrDisabled = errors.New("act: disabled")
-
 	// ErrCfgLoad means cfg load error.
 	ErrCfgLoad = errors.New("act: cfg load error")
 )

--- a/pkg/plat/preset/act/exile.go
+++ b/pkg/plat/preset/act/exile.go
@@ -13,6 +13,7 @@ import (
 	"github.com/defended-net/malwatch/pkg/boot/env"
 	"github.com/defended-net/malwatch/pkg/boot/env/cfg/secret"
 	"github.com/defended-net/malwatch/pkg/client/s3"
+	"github.com/defended-net/malwatch/pkg/plat/acter"
 	"github.com/defended-net/malwatch/pkg/scan/state"
 )
 
@@ -35,6 +36,10 @@ func NewExiler(env *env.Env) *Exiler {
 
 // Load loads a given exiler.
 func (exiler *Exiler) Load() error {
+	if exiler.secrets.Endpoint == "" {
+		return acter.ErrDisabled
+	}
+
 	transport, err := s3.New(exiler.secrets)
 	if err != nil {
 		return err

--- a/pkg/plat/preset/act/preset.go
+++ b/pkg/plat/preset/act/preset.go
@@ -1,0 +1,16 @@
+package act
+
+import (
+	"github.com/defended-net/malwatch/pkg/boot/env"
+	"github.com/defended-net/malwatch/pkg/plat/acter"
+)
+
+// Preset returns preset acts for given env.
+func Preset(env *env.Env) []acter.Acter {
+	return []acter.Acter{
+		NewExiler(env),
+		NewQuarantiner(env),
+		NewCleaner(env),
+		NewAlerter(env),
+	}
+}

--- a/pkg/plat/preset/act/quarantine.go
+++ b/pkg/plat/preset/act/quarantine.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/defended-net/malwatch/pkg/boot/env"
 	"github.com/defended-net/malwatch/pkg/fsys"
+	"github.com/defended-net/malwatch/pkg/plat/acter"
 	"github.com/defended-net/malwatch/pkg/scan/state"
 )
 
@@ -29,7 +30,7 @@ func NewQuarantiner(env *env.Env) *Quarantiner {
 // Load loads a given quarantiner.
 func (quarantiner *Quarantiner) Load() error {
 	if quarantiner.dir == "" {
-		return ErrDisabled
+		return acter.ErrDisabled
 	}
 
 	return nil

--- a/pkg/plat/preset/preset.go
+++ b/pkg/plat/preset/preset.go
@@ -25,33 +25,20 @@ type Cfg struct {
 // New returns a plat from given env.
 func New(env *env.Env) *Plat {
 	return &Plat{
-		env: env,
-
-		acters: []acter.Acter{
-			act.NewExiler(env),
-			act.NewQuarantiner(env),
-			act.NewCleaner(env),
-			act.NewAlerter(env),
-		},
-
-		// default plat, not much of a cfg.
-		cfg: &Cfg{
-			path: "",
-		},
+		env:    env,
+		acters: act.Preset(env),
+		cfg:    &Cfg{},
 	}
 }
 
 // Load reads given plat cfg files.
 func (plat *Plat) Load() error {
-	enabled := []acter.Acter{}
-
-	for _, acter := range plat.acters {
-		if err := acter.Load(); err == nil {
-			enabled = append(enabled, acter)
-		}
+	acters, err := acter.Load(plat.acters)
+	if err != nil {
+		return err
 	}
 
-	plat.acters = enabled
+	plat.acters = acters
 
 	return nil
 }

--- a/pkg/plat/preset/preset_test.go
+++ b/pkg/plat/preset/preset_test.go
@@ -60,7 +60,7 @@ func TestPath(t *testing.T) {
 
 func TestActers(t *testing.T) {
 	var (
-		input = acter.Mock(act.VerbAlert)
+		input = acter.Mock(act.VerbAlert, true)
 
 		plat = &Plat{
 			acters: []acter.Acter{

--- a/pkg/plat/preset/preset_test.go
+++ b/pkg/plat/preset/preset_test.go
@@ -27,6 +27,8 @@ func TestLoad(t *testing.T) {
 		t.Fatalf("env mock error: %v", err)
 	}
 
+	env.Cfg.Acts.Quarantine.Dir = ""
+
 	env.Plat = New(env)
 
 	if err := env.Plat.Load(); err != nil {
@@ -49,8 +51,12 @@ func TestCfg(t *testing.T) {
 func TestPath(t *testing.T) {
 	var (
 		want = t.TempDir()
-		plat = &Plat{cfg: &Cfg{path: want}}
-		got  = plat.Cfg().Path()
+
+		plat = &Plat{
+			cfg: &Cfg{path: want},
+		}
+
+		got = plat.Cfg().Path()
 	)
 
 	if got != want {

--- a/pkg/scan/job/job_test.go
+++ b/pkg/scan/job/job_test.go
@@ -169,7 +169,7 @@ func TestNew(t *testing.T) {
 
 func TestActs(t *testing.T) {
 	var (
-		mock   = acter.Mock(t.Name())
+		mock   = acter.Mock(t.Name(), true)
 		result = &state.Result{}
 	)
 


### PR DESCRIPTION
feat: directadmin integration issue #6
refactor: exec pkg for integration cmds
refactor: use new exec for cpanel integration
refactor: improve cpanel integration cfg tests
refactor: add preset actions to simplify integration callsites
refactor: use new preset actions for cpanel integration
refactor: add central acter loader including enable filtering
refactor: use filtered return for new acter loading and update tests
tests: improve and fix tests for new acter handling
tests: add directadmin marshal err checks

Many integration apis require execution toward `stdout` rather than directly over http / socket, etc. This is the first step needed to further develop integrations in a safe, reliable and uniform manner.