### PR TITLE
1.2.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,9 +35,9 @@ There is tremendous value if malwatch is elected to replace your fleet's existin
 
 Create a directory anywhere you prefer, software is meant to be portable. A common choice is `/opt/malwatch`. Then extract the binary there from the downloaded archive:
 
-    wget https://github.com/defended-net/malwatch/releases/download/v1.2.1/malwatch_1.2.1_linux_amd64.tar.gz
+    wget https://github.com/defended-net/malwatch/releases/download/v1.2.2/malwatch_1.2.2_linux_amd64.tar.gz
     mkdir /opt/malwatch
-    tar -C /opt/malwatch -xzvf malwatch_1.2.1_linux_amd64.tar.gz
+    tar -C /opt/malwatch -xzvf malwatch_1.2.2_linux_amd64.tar.gz
 
 It would be recommended to integrate it with your `PATH`:
 

--- a/pkg/fsys/fsys.go
+++ b/pkg/fsys/fsys.go
@@ -261,19 +261,24 @@ func HasDotDots(paths ...string) error {
 	return nil
 }
 
-// IsExpired verifies is a file has exceeded a max mtime. Includes timestomp protection for ctime.
-func IsExpired(expiry time.Time, path string) (*unix.Stat_t, bool) {
+// IsExp verifies is a file has exceeded max mtime. Timestomp protection with ctime.
+func IsExp(expiry time.Time, path string) (bool, *unix.Stat_t) {
 	stat := &unix.Stat_t{}
 
+	// Error handling can be pushed down for next steps in scan,
+	// such as file opening.
 	if err := unix.Stat(path, stat); err != nil {
-		return stat, true
+		return false, nil
 	}
 
-	cTime, mTime := time.Unix(stat.Ctim.Sec, 0), time.Unix(stat.Mtim.Sec, 0)
+	var (
+		cTime = time.Unix(stat.Ctim.Sec, 0)
+		mTime = time.Unix(stat.Mtim.Sec, 0)
+	)
 
 	if cTime.Before(expiry) && mTime.Before(expiry) {
-		return stat, true
+		return true, nil
 	}
 
-	return stat, false
+	return false, stat
 }

--- a/pkg/fsys/fsys_test.go
+++ b/pkg/fsys/fsys_test.go
@@ -407,7 +407,7 @@ func TestIsExpired(t *testing.T) {
 		t.Fatalf("file create error: %s", err)
 	}
 
-	if _, result := IsExpired(time.Now().Add(time.Hour*24), input); result != true {
+	if result, _ := IsExp(time.Now().Add(time.Hour*24), input); result != true {
 		t.Errorf("unexpected is expired result %v, want %v", result, true)
 	}
 }
@@ -440,7 +440,7 @@ func TestIsExpiredTimestomp(t *testing.T) {
 				t.Errorf("mtime alert error: %s", err)
 			}
 
-			if _, result := IsExpired(time.Now().Add(-(time.Hour * 24)), path); result != test.want {
+			if result, _ := IsExp(time.Now().Add(-(time.Hour * 24)), path); result != test.want {
 				t.Errorf("unexpected is expired timestomp result %v, want %v", result, test.want)
 			}
 		})

--- a/pkg/monitor/monitor.go
+++ b/pkg/monitor/monitor.go
@@ -76,7 +76,7 @@ func New(env *env.Env) (*Monitor, error) {
 
 	for thread := 1; thread <= env.Cfg.Threads; thread++ {
 		// File expiration is irrelevant for monitor.
-		worker, err := worker.New(env.Cfg, rules, 0)
+		worker, err := worker.New(env.Cfg, rules)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/plat/preset/act/preset.go
+++ b/pkg/plat/preset/act/preset.go
@@ -1,3 +1,6 @@
+// © Roscoe Skeens <rskeens@defended.net>
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 package act
 
 import (

--- a/pkg/scan/job/job_test.go
+++ b/pkg/scan/job/job_test.go
@@ -40,7 +40,7 @@ func TestStart(t *testing.T) {
 
 	job := New("target", &Paths{}, 0, 1, []acter.Acter{}, []func(*state.Result) error{}, true)
 
-	worker, err := worker.New(env.Cfg, rules, 0)
+	worker, err := worker.New(env.Cfg, rules)
 	if err != nil {
 		t.Fatalf("worker create error: %v", err)
 	}
@@ -109,7 +109,7 @@ func TestStopNoHit(t *testing.T) {
 		job = New("target", &Paths{}, time.Second, 3, []acter.Acter{}, task, true)
 	)
 
-	worker, err := worker.New(env.Cfg, rules, 0)
+	worker, err := worker.New(env.Cfg, rules)
 	if err != nil {
 		t.Fatalf("worker create error: %v", err)
 	}

--- a/pkg/scan/scan.go
+++ b/pkg/scan/scan.go
@@ -53,7 +53,7 @@ func New(env *env.Env, paths ...string) (*Scan, error) {
 	scan.addJobs(env, paths)
 
 	for thread := 1; thread <= env.Cfg.Threads; thread++ {
-		worker, err := worker.New(env.Cfg, rules, env.Cfg.Scans.MaxAge)
+		worker, err := worker.New(env.Cfg, rules)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/scan/worker/worker.go
+++ b/pkg/scan/worker/worker.go
@@ -30,13 +30,12 @@ import (
 type Worker struct {
 	scanner *yr.Scanner
 	matches yr.MatchRules
-	buff    []byte
 	acts    *act.Cfg
-	blkSz   int
+	buff    []byte
 	exp     time.Time
 	expFn   func(time.Time, string) (bool, *unix.Stat_t)
-	err     error
 	offset  int
+	err     error
 }
 
 // New returns a worker from given cfg, rules and max file age.
@@ -52,7 +51,6 @@ func New(cfg *base.Cfg, rules *yr.Rules) (*Worker, error) {
 		scanner: scanner.SetFlags(yr.ScanFlagsFastMode),
 		buff:    make([]byte, blkSz),
 		acts:    cfg.Acts,
-		blkSz:   blkSz,
 		exp:     time.Now().AddDate(0, 0, -cfg.Scans.MaxAge),
 		expFn:   noop,
 	}

--- a/pkg/scan/worker/worker_test.go
+++ b/pkg/scan/worker/worker_test.go
@@ -31,7 +31,7 @@ func TestNew(t *testing.T) {
 		t.Fatalf("yara load error: %v", err)
 	}
 
-	if _, err := New(env.Cfg, rules, 0); err != nil {
+	if _, err := New(env.Cfg, rules); err != nil {
 		t.Errorf("worker create error: %v", err)
 	}
 }
@@ -124,7 +124,7 @@ func TestMatchesToString(t *testing.T) {
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			result := MatchesToString(test.input)
+			result := MatchesToStr(test.input)
 
 			if !slices.Equal(result, test.want) {
 				t.Errorf("unexpected matches to string result %v, want %v", result, test.want)


### PR DESCRIPTION
refactor: scan worker loop rewritten with allocations substantially reduced per iteration
refactor: reduced param count for scan worker constructor
refactor: worker fields cleanup
refactor: is expired fn return order changed
tests: compatibility tweaks for refactoring

Scan worker iterative errors and file read offsets are now reused. The file read buffer is also no longer reallocated per offset.