### PR TITLE
1.4.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,9 +38,9 @@ There is tremendous value if malwatch is elected to replace your fleet's existin
 
 Create a directory anywhere you prefer, software is meant to be portable. A common choice is `/opt/malwatch`. Then extract the binary there from the downloaded archive:
 
-    wget https://github.com/defended-net/malwatch/releases/download/v1.4.1/malwatch_1.4.1_linux_amd64.tar.gz
+    wget https://github.com/defended-net/malwatch/releases/download/v1.4.2/malwatch_1.4.2_linux_amd64.tar.gz
     mkdir /opt/malwatch
-    tar -C /opt/malwatch -xzvf malwatch_1.4.1_linux_amd64.tar.gz
+    tar -C /opt/malwatch -xzvf malwatch_1.4.2_linux_amd64.tar.gz
 
 It would be recommended to integrate it with your `PATH`:
 

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	dario.cat/mergo v1.0.0 // indirect
 	github.com/Microsoft/go-winio v0.6.2 // indirect
 	github.com/ProtonMail/go-crypto v1.1.6 // indirect
-	github.com/cloudflare/circl v1.6.1 // indirect
+	github.com/cloudflare/circl v1.6.3 // indirect
 	github.com/cyphar/filepath-securejoin v0.4.1 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/emirpasic/gods v1.18.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -15,8 +15,8 @@ github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPd
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/caarlos0/env/v11 v11.3.1 h1:cArPWC15hWmEt+gWk7YBi7lEXTXCvpaSdCiZE2X5mCA=
 github.com/caarlos0/env/v11 v11.3.1/go.mod h1:qupehSf/Y0TUTsxKywqRt/vJjN5nz6vauiYEUUr8P4U=
-github.com/cloudflare/circl v1.6.1 h1:zqIqSPIndyBh1bjLVVDHMPpVKqp8Su/V+6MeDzzQBQ0=
-github.com/cloudflare/circl v1.6.1/go.mod h1:uddAzsPgqdMAYatqJ0lsjX1oECcQLIlRpzZh3pJrofs=
+github.com/cloudflare/circl v1.6.3 h1:9GPOhQGF9MCYUeXyMYlqTR6a5gTrgR/fBLXvUgtVcg8=
+github.com/cloudflare/circl v1.6.3/go.mod h1:2eXP6Qfat4O/Yhh8BznvKnJ+uzEoTQ6jVKJRn81BiS4=
 github.com/cyphar/filepath-securejoin v0.4.1 h1:JyxxyPEaktOD+GAnqIqTf9A8tHyAG22rowi7HkoSU1s=
 github.com/cyphar/filepath-securejoin v0.4.1/go.mod h1:Sdj7gXlvMcPZsbhwhQ33GguGLDGQL7h7bg04C/+u9jI=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/pkg/scan/job/job.go
+++ b/pkg/scan/job/job.go
@@ -22,7 +22,7 @@ import (
 	"github.com/defended-net/malwatch/pkg/tui"
 )
 
-// Job represents a scan job. Each target can have exactly one job.
+// Job represents scan job. Each target can have exactly one job.
 type Job struct {
 	Target  string
 	State   *state.Job
@@ -41,7 +41,7 @@ type Paths struct {
 	Dirs  []string
 }
 
-// New returns a new job.
+// New returns new job.
 func New(target string, paths *Paths, timeout time.Duration, batchSz int, acters []acter.Acter, tasks []func(*state.Result) error, ticker bool) *Job {
 	job := &Job{
 		Target:  target,
@@ -60,9 +60,9 @@ func New(target string, paths *Paths, timeout time.Duration, batchSz int, acters
 	return job
 }
 
-// Walk traverses paths.
+// Walk traverses paths for given job.
 // File counting done here in single thread to avoid lock contention from workers handling it.
-func (job *Job) Walk(skips *act.Skips, sz int) chan string {
+func (job *Job) Walk(skips *act.Skips, sz int) <-chan string {
 	queue := make(chan string, sz)
 
 	go func() {
@@ -96,7 +96,7 @@ func (job *Job) Walk(skips *act.Skips, sz int) chan string {
 	return queue
 }
 
-// Start starts a job.
+// Start starts given job.
 func (job *Job) Start(ctx context.Context, skips *act.Skips, workers ...*worker.Worker) {
 	go job.spinner.Start()
 	queue := job.Walk(skips, job.batchSz)
@@ -115,43 +115,39 @@ func (job *Job) Start(ctx context.Context, skips *act.Skips, workers ...*worker.
 	}()
 }
 
-// Stop stops a job.
+// Stop stops given job by flushing hits.
 func (job *Job) Stop() {
-	var (
-		idx  int
-		hits = []*state.Hit{}
-	)
+	hits := make([]*state.Hit, 0, job.batchSz)
 
 	for hit := range job.State.Hits {
-		idx++
 		hits = append(hits, hit)
 
-		if idx > job.batchSz {
-			grouped := state.Group(job.Target, hits)
-
-			for _, result := range grouped {
-				job.Acts(result)
-				job.Tasks(result)
-			}
-
-			hits = nil
-			idx = 0
+		if len(hits) >= job.batchSz {
+			job.flush(hits)
+			hits = hits[:0]
 		}
 	}
 
-	grouped := state.Group(job.Target, hits)
-
-	for _, result := range grouped {
-		job.Acts(result)
-		job.Tasks(result)
-	}
+	job.flush(hits)
 
 	for _, err := range job.State.Errs() {
 		slog.Error(err.Error())
 	}
 }
 
-// Acts performs actions with a given result.
+// flush first performs acts and then tasks for given hits.
+func (job *Job) flush(hits []*state.Hit) {
+	if len(hits) == 0 {
+		return
+	}
+
+	for _, result := range state.Group(job.Target, hits) {
+		job.Acts(result)
+		job.Tasks(result)
+	}
+}
+
+// Acts performs acts for given result.
 func (job *Job) Acts(result *state.Result) {
 	for _, acter := range job.acters {
 		filtered := FilterAct(result, acter.Verb())
@@ -166,7 +162,7 @@ func (job *Job) Acts(result *state.Result) {
 	}
 }
 
-// Tasks performs tasks with a given result.
+// Tasks performs tasks for given result.
 func (job *Job) Tasks(result *state.Result) {
 	for _, task := range job.tasks {
 		if err := task(result); err != nil {
@@ -175,7 +171,7 @@ func (job *Job) Tasks(result *state.Result) {
 	}
 }
 
-// FilterAct returns grouped hits from given act verb.
+// FilterAct returns grouped hits for given act verb.
 func FilterAct(result *state.Result, verb string) *state.Result {
 	filtered := state.NewResult(result.Target, state.Paths{})
 

--- a/pkg/scan/job/job_test.go
+++ b/pkg/scan/job/job_test.go
@@ -107,10 +107,10 @@ func TestStopNoHit(t *testing.T) {
 
 	job.Stop()
 
-	if _, err := os.Stat(path); err != nil {
-		if os.IsNotExist(err) {
-			t.Errorf("task flag file not found: %v", path)
-		}
+	if _, err := os.Stat(path); err == nil {
+		t.Errorf("task flag file should not exist: %v", path)
+	} else if !os.IsNotExist(err) {
+		t.Fatalf("stat error: %v", err)
 	}
 }
 

--- a/pkg/scan/state/hit.go
+++ b/pkg/scan/state/hit.go
@@ -22,40 +22,15 @@ type Paths map[string]*hit.Meta
 // Group returns a slice of results from given slice of hits.
 func Group(target string, hits []*Hit) []*Result {
 	if len(hits) == 0 {
-		return []*Result{
-			NewResult(target, Paths{}),
-		}
+		return []*Result{NewResult(target, Paths{})}
 	}
 
-	grouped := map[string]*Result{}
+	grouped := make(map[string]*Result, len(hits))
 
 	for _, hit := range hits {
-		target = re.Target(hit.Path)
+		target := re.Target(hit.Path)
 
-		result, exists := grouped[target]
-		if !exists {
-			grouped[target] = NewResult(
-				target,
-
-				Paths{
-					hit.Path: hit.Meta,
-				},
-			)
-
-			continue
-		}
-
-		meta, exists := result.Paths[hit.Path]
-		if !exists {
-			result.Paths[hit.Path] = hit.Meta
-			continue
-		}
-
-		for _, rule := range hit.Meta.Rules {
-			if !slices.Contains(meta.Rules, rule) {
-				meta.Rules = append(meta.Rules, rule)
-			}
-		}
+		add(grouped, target, hit)
 	}
 
 	results := make([]*Result, 0, len(grouped))
@@ -65,4 +40,38 @@ func Group(target string, hits []*Hit) []*Result {
 	}
 
 	return results
+}
+
+func add(grouped map[string]*Result, target string, hit *Hit) {
+	result := grouped[target]
+
+	if result == nil {
+		grouped[target] = NewResult(
+			target,
+
+			Paths{
+				hit.Path: hit.Meta,
+			},
+		)
+
+		return
+	}
+
+	current := result.Paths[hit.Path]
+
+	if current == nil {
+		result.Paths[hit.Path] = hit.Meta
+
+		return
+	}
+
+	merge(hit.Meta, current)
+}
+
+func merge(src *hit.Meta, dst *hit.Meta) {
+	for _, rule := range src.Rules {
+		if !slices.Contains(dst.Rules, rule) {
+			dst.Rules = append(dst.Rules, rule)
+		}
+	}
 }

--- a/pkg/scan/worker/worker.go
+++ b/pkg/scan/worker/worker.go
@@ -60,7 +60,7 @@ func New(cfg *base.Cfg) (*Worker, error) {
 }
 
 // Work receives given queued paths to scan.
-func (worker *Worker) Work(ctx context.Context, state *state.Job, queue chan string) {
+func (worker *Worker) Work(ctx context.Context, state *state.Job, queue <-chan string) {
 	defer state.WGrp.Done()
 
 	for path := range queue {

--- a/pkg/tui/spin.go
+++ b/pkg/tui/spin.go
@@ -5,24 +5,25 @@ package tui
 
 import (
 	"fmt"
+	"sync"
+	"sync/atomic"
 	"time"
 )
 
 // Spinner represents a progress spinner.
 type Spinner struct {
-	tick     *time.Ticker
-	interval time.Duration
 	msg      string
-	stop     chan (struct{})
+	interval time.Duration
+	running  atomic.Bool
+	once     sync.Once
+	done     sync.WaitGroup
 }
 
 // NewSpinner returns a spinner from given interval and message.
 func NewSpinner(interval time.Duration, msg string) *Spinner {
 	return &Spinner{
-		tick:     time.NewTicker(interval),
 		interval: interval,
 		msg:      msg,
-		stop:     make(chan struct{}, 1),
 	}
 }
 
@@ -32,33 +33,27 @@ func (spinner *Spinner) Start() {
 		return
 	}
 
-	defer close(spinner.stop)
-	defer spinner.Stop()
+	spinner.running.Store(true)
 
-	tick := []string{
-		"-",
-		"\\",
-		"|",
-		"/",
+	spinner.done.Add(1)
+	defer spinner.done.Done()
+
+	var (
+		ticker = time.NewTicker(spinner.interval)
+		idx    = 0
+		tick   = []string{"-", "\\", "|", "/"}
+	)
+
+	defer ticker.Stop()
+
+	for spinner.running.Load() {
+		<-ticker.C
+
+		fmt.Printf("\r%v [%v]", spinner.msg, tick[idx])
+		idx = (idx + 1) % len(tick)
 	}
 
-	idx := 0
-
-	for {
-		select {
-		case <-spinner.stop:
-			return
-
-		case <-spinner.tick.C:
-			fmt.Printf("\r%v [%v]", spinner.msg, tick[idx])
-
-			idx++
-
-			if idx > 3 {
-				idx = 0
-			}
-		}
-	}
+	fmt.Printf("\r\033[2K")
 }
 
 // Stop stops a spinner.
@@ -67,10 +62,8 @@ func (spinner *Spinner) Stop() {
 		return
 	}
 
-	spinner.tick.Stop()
-	spinner.stop <- struct{}{}
-
-	// Clear.
-	fmt.Printf("\r")
-	fmt.Printf("\033[2K")
+	spinner.once.Do(func() {
+		spinner.running.Store(false)
+		spinner.done.Wait()
+	})
 }

--- a/pkg/tui/spin_test.go
+++ b/pkg/tui/spin_test.go
@@ -38,7 +38,7 @@ func TestStart(t *testing.T) {
 func TestStartNil(t *testing.T) {
 	defer func() {
 		if err := recover(); err != nil {
-			t.Fatalf("unexpected panic during nil spinner start")
+			t.Fatalf("unexpected nil spinner start panic")
 		}
 	}()
 

--- a/pkg/tui/yesno.go
+++ b/pkg/tui/yesno.go
@@ -15,13 +15,10 @@ import (
 func YesNo(msg string, reader io.Reader) bool {
 	fmt.Printf("%s [y/n] ", msg)
 
-	var (
-		scanner = bufio.NewScanner(reader)
-		input   = ""
-	)
+	scanner := bufio.NewScanner(reader)
 
 	for scanner.Scan() {
-		input = strings.ToLower(strings.TrimSpace(scanner.Text()))
+		input := strings.ToLower(strings.TrimSpace(scanner.Text()))
 
 		switch input {
 		case "y", "yes":

--- a/pkg/tui/yesno.go
+++ b/pkg/tui/yesno.go
@@ -15,16 +15,19 @@ import (
 func YesNo(msg string, reader io.Reader) bool {
 	fmt.Printf("%s [y/n] ", msg)
 
-	scanner := bufio.NewScanner(reader)
+	var (
+		scanner = bufio.NewScanner(reader)
+		input   = ""
+	)
 
 	for scanner.Scan() {
-		input := strings.ToLower(scanner.Text())
+		input = strings.ToLower(strings.TrimSpace(scanner.Text()))
 
 		switch input {
-		case "y":
+		case "y", "yes":
 			return true
 
-		case "n":
+		case "n", "no":
 			return false
 		}
 


### PR DESCRIPTION
sec: update `cloudflare/circl` to `1.6.3`
refactor: atomic semantics for progress spinner
refactor: scan job batch handling and grouping
refactor: scan state batch handling and grouping
refactor: rescope scan worker queue chan
refactor: support robust confirmation input
tests: scan job batch handling and grouping
tests: progress spinner rewording
docs: bump download release

Vulnerability affecting `cloudflare/circl` as `GO-2026-4550` resolved https://pkg.go.dev/vuln/GO-2026-4550 This project was unaffected by these third party vulnerabilities.