### PR TITLE
1.5.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,9 +38,9 @@ There is tremendous value if malwatch is elected to replace your fleet's existin
 
 Create a directory anywhere you prefer, software is meant to be portable. A common choice is `/opt/malwatch`. Then extract the binary there from the downloaded archive:
 
-    wget https://github.com/defended-net/malwatch/releases/download/v1.5.1/malwatch_1.5.1_linux_amd64.tar.gz
+    wget https://github.com/defended-net/malwatch/releases/download/v1.5.2/malwatch_1.5.2_linux_amd64.tar.gz
     mkdir /opt/malwatch
-    tar -C /opt/malwatch -xzvf malwatch_1.5.1_linux_amd64.tar.gz
+    tar -C /opt/malwatch -xzvf malwatch_1.5.2_linux_amd64.tar.gz
 
 It would be recommended to integrate it with your `PATH`:
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
   <h2 align="center">Fast and lightweight malware scanning</h2>
 </p>
 
-![GitHub License](https://img.shields.io/github/license/defended-net/malwatch) [![Go Report Card](https://goreportcard.com/badge/github.com/defended-net/malwatch)](https://goreportcard.com/report/github.com/defended-net/malwatch)
+![GitHub License](https://img.shields.io/github/license/defended-net/malwatch)
 
 Malwatch is a fast and lightweight malware scanner written in `go` for Linux based web server environments. It is capable of scaling to any requirements and is in production with some of the internet's largest deployments.
 

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/BurntSushi/toml v1.6.0
 	github.com/alexeyco/simpletable v1.0.0
 	github.com/caarlos0/env/v11 v11.4.1
-	github.com/go-git/go-git/v5 v5.19.0
+	github.com/go-git/go-git/v5 v5.19.1
 	github.com/minio/minio-go/v7 v7.1.0
 	github.com/rwtodd/Go.Sed v0.0.0-20190103233418-906bc69c9394
 	github.com/wneessen/go-mail v0.7.2

--- a/go.mod
+++ b/go.mod
@@ -48,6 +48,6 @@ require (
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/crypto v0.52.0 // indirect
 	golang.org/x/net v0.54.0 // indirect
-	golang.org/x/text v0.37.0 // indirect
+	golang.org/x/text v0.39.0 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -38,8 +38,8 @@ github.com/go-git/go-billy/v5 v5.9.0 h1:jItGXszUDRtR/AlferWPTMN4j38BQ88XnXKbilmm
 github.com/go-git/go-billy/v5 v5.9.0/go.mod h1:jCnQMLj9eUgGU7+ludSTYoZL/GGmii14RxKFj7ROgHw=
 github.com/go-git/go-git-fixtures/v4 v4.3.2-0.20231010084843-55a94097c399 h1:eMje31YglSBqCdIqdhKBW8lokaMrL3uTkpGYlE2OOT4=
 github.com/go-git/go-git-fixtures/v4 v4.3.2-0.20231010084843-55a94097c399/go.mod h1:1OCfN199q1Jm3HZlxleg+Dw/mwps2Wbk9frAWm+4FII=
-github.com/go-git/go-git/v5 v5.19.0 h1:+WkVUQZSy/F1Gb13udrMKjIM2PrzsNfDKFSfo5tkMtc=
-github.com/go-git/go-git/v5 v5.19.0/go.mod h1:Pb1v0c7/g8aGQJwx9Us09W85yGoyvSwuhEGMH7zjDKQ=
+github.com/go-git/go-git/v5 v5.19.1 h1:nX27AnaU43/K5bKktKwgBmR9lawoYVe1Ckg0rgzzN00=
+github.com/go-git/go-git/v5 v5.19.1/go.mod h1:Pb1v0c7/g8aGQJwx9Us09W85yGoyvSwuhEGMH7zjDKQ=
 github.com/go-ini/ini v1.67.0 h1:z6ZrTEZqSWOTyH2FlglNbNgARyHG8oLW9gMELqKr06A=
 github.com/go-ini/ini v1.67.0/go.mod h1:ByCAeIL28uOIIG0E3PJtZPDL8WnHpFKFOtgjp+3Ies8=
 github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8 h1:f+oWsMOmNPc8JmEHVZIycC7hBoQxHH9pNKQORJNozsQ=

--- a/go.sum
+++ b/go.sum
@@ -124,8 +124,8 @@ golang.org/x/exp v0.0.0-20260410095643-746e56fc9e2f/go.mod h1:J1xhfL/vlindoeF/aI
 golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.54.0 h1:2zJIZAxAHV/OHCDTCOHAYehQzLfSXuf/5SoL/Dv6w/w=
 golang.org/x/net v0.54.0/go.mod h1:Sj4oj8jK6XmHpBZU/zWHw3BV3abl4Kvi+Ut7cQcY+cQ=
-golang.org/x/sync v0.20.0 h1:e0PTpb7pjO8GAtTs2dQ6jYa5BWYlMuX047Dco/pItO4=
-golang.org/x/sync v0.20.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=
+golang.org/x/sync v0.21.0 h1:HLII4xRRTtCRkxYp4HNFF0Js/Og6q2i++KXbg0gHCwM=
+golang.org/x/sync v0.21.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=
 golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -138,8 +138,8 @@ golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9sn
 golang.org/x/term v0.43.0 h1:S4RLU2sB31O/NCl+zFN9Aru9A/Cq2aqKpTZJ6B+DwT4=
 golang.org/x/term v0.43.0/go.mod h1:lrhlHNdQJHO+1qVYiHfFKVuVioJIheAc3fBSMFYEIsk=
 golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
-golang.org/x/text v0.37.0 h1:Cqjiwd9eSg8e0QAkyCaQTNHFIIzWtidPahFWR83rTrc=
-golang.org/x/text v0.37.0/go.mod h1:a5sjxXGs9hsn/AJVwuElvCAo9v8QYLzvavO5z2PiM38=
+golang.org/x/text v0.39.0 h1:UbZz4pLOvn600D6Oh6GGEI6VAmndrEBLv8/6BEXzyus=
+golang.org/x/text v0.39.0/go.mod h1:3UwRclnC2g0TU9x8PZiyfOajCd1zaUNHF9cvqcQZ+ZM=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/pkg/fsys/fsys_test.go
+++ b/pkg/fsys/fsys_test.go
@@ -1172,7 +1172,10 @@ func TestIsExp(t *testing.T) {
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			input := filepath.Join(t.TempDir(), "file")
+			var (
+				input = filepath.Join(t.TempDir(), "file")
+				stat  = &unix.Stat_t{}
+			)
 
 			if _, err := os.Create(input); err != nil {
 				t.Fatalf("file create err %s", err)
@@ -1190,7 +1193,7 @@ func TestIsExp(t *testing.T) {
 			}
 			defer Close(file)
 
-			if got, _ := IsExp(test.ttl(), int(file.Fd())); got != test.want {
+			if got := IsExp(test.ttl(), int(file.Fd()), stat); got != test.want {
 				t.Errorf("unexpected is exp result %v, want %v", got, test.want)
 			}
 		})
@@ -1198,13 +1201,8 @@ func TestIsExp(t *testing.T) {
 }
 
 func TestIsExpErrs(t *testing.T) {
-	got, stat := IsExp(time.Now(), -1)
-	if got {
+	if got := IsExp(time.Now(), -1, &unix.Stat_t{}); got {
 		t.Errorf("unexpected is exp result %v, want false", got)
-	}
-
-	if stat != nil {
-		t.Errorf("unexpected stat %v, want nil", stat)
 	}
 }
 

--- a/pkg/fsys/valid.go
+++ b/pkg/fsys/valid.go
@@ -15,11 +15,9 @@ import (
 )
 
 // IsExp verifies if given file has exceeded mtime. Timestomp protected.
-func IsExp(expiry time.Time, fd int) (bool, *unix.Stat_t) {
-	stat := &unix.Stat_t{}
-
+func IsExp(expiry time.Time, fd int, stat *unix.Stat_t) bool {
 	if err := unix.Fstat(fd, stat); err != nil {
-		return false, nil
+		return false
 	}
 
 	var (
@@ -28,10 +26,10 @@ func IsExp(expiry time.Time, fd int) (bool, *unix.Stat_t) {
 	)
 
 	if cTime.Before(expiry) && mTime.Before(expiry) {
-		return true, nil
+		return true
 	}
 
-	return false, stat
+	return false
 }
 
 // IsRel verifies if given path is rel to given base paths.

--- a/pkg/scan/worker/worker.go
+++ b/pkg/scan/worker/worker.go
@@ -30,8 +30,9 @@ type Worker struct {
 	matches matches
 	acts    *act.Cfg
 	buff    []byte
+	stat    *unix.Stat_t
+	maxAge  int
 	exp     time.Time
-	expFn   func(time.Time, int) (bool, *unix.Stat_t)
 }
 
 // matches represents matched rules.
@@ -39,19 +40,18 @@ type matches []string
 
 // New returns a worker from given cfg, rules and max file age.
 func New(cfg *base.Cfg) (*Worker, error) {
-	// #nosec G404 -- non crypto jitter.
-	blkSz := int(float64(cfg.Scans.BlkSz) * (0.8 + rand.Float64()*0.2))
+	var (
+		// #nosec G404 -- non crypto jitter.
+		blkSz = int(float64(cfg.Scans.BlkSz) * (0.8 + rand.Float64()*0.2))
 
-	worker := &Worker{
-		buff:  make([]byte, blkSz),
-		acts:  cfg.Acts,
-		exp:   time.Now().AddDate(0, 0, -cfg.Scans.MaxAge),
-		expFn: noop,
-	}
-
-	if cfg.Scans.MaxAge != 0 {
-		worker.expFn = fsys.IsExp
-	}
+		worker = &Worker{
+			acts:   cfg.Acts,
+			buff:   make([]byte, blkSz),
+			stat:   &unix.Stat_t{},
+			maxAge: cfg.Scans.MaxAge,
+			exp:    time.Now().AddDate(0, 0, -cfg.Scans.MaxAge),
+		}
+	)
 
 	if err := worker.Refresh(); err != nil {
 		return nil, err
@@ -95,8 +95,7 @@ func (worker *Worker) Scan(path string, result *state.Job) {
 	// nolint
 	defer unix.Close(fd)
 
-	exp, stat := worker.expFn(worker.exp, fd)
-	if exp {
+	if worker.maxAge != 0 && fsys.IsExp(worker.exp, fd, worker.stat) {
 		return
 	}
 
@@ -135,23 +134,18 @@ out:
 		return
 	}
 
-	// Reuse from beginning of fn, otherwise start from scratch.
-	if stat == nil {
-		stat = &unix.Stat_t{}
-
-		if err := unix.Fstat(fd, stat); err != nil {
-			result.AddErr(fmt.Errorf("%w, %v, %v", fsys.ErrStat, err, path))
-		}
-	}
-
 	matches := slices.Clone(worker.matches)
 	slices.Sort(matches)
+
+	if err := unix.Fstat(fd, worker.stat); err != nil {
+		result.AddErr(fmt.Errorf("%w, %v, %v", fsys.ErrStat, err, path))
+	}
 
 	result.Hits <- &state.Hit{
 		Path: path,
 
 		Meta: hit.NewMeta(
-			fsys.NewAttr(stat),
+			fsys.NewAttr(worker.stat),
 			matches,
 			worker.acts.NewVerbs(path, matches...)...,
 		),
@@ -198,10 +192,6 @@ func (matches *matches) RuleMatching(_ *yr.ScanContext, rule *yr.Rule) (bool, er
 	*matches = append(*matches, hit)
 
 	return len(*matches) > 3, nil
-}
-
-func noop(_ time.Time, _ int) (bool, *unix.Stat_t) {
-	return false, nil
 }
 
 // Mock mocks a worker.

--- a/third_party/yr/scanner.go
+++ b/third_party/yr/scanner.go
@@ -39,6 +39,9 @@ type Scanner struct {
 	// userData stores handle of the currently set callback object. It is
 	// allocated using malloc so that the GC does not mess with it.
 	userData *cgoHandle
+	// prepared tracks whether callback and flags have been set on the
+	// underlying C scanner. Reset when Callback or flags change.
+	prepared bool
 }
 
 // Creates a new error that includes information a about the rule
@@ -85,6 +88,7 @@ func (s *Scanner) Destroy() {
 		C.free(unsafe.Pointer(s.userData))
 		s.userData = nil
 	}
+	s.prepared = false
 	runtime.SetFinalizer(s, nil)
 }
 
@@ -123,6 +127,7 @@ func (s *Scanner) DefineVariable(identifier string, value interface{}) (err erro
 // SetFlags sets flags for the scanner.
 func (s *Scanner) SetFlags(flags ScanFlags) *Scanner {
 	s.flags = flags
+	s.prepared = false
 	return s
 }
 
@@ -134,12 +139,13 @@ func (s *Scanner) SetTimeout(timeout time.Duration) *Scanner {
 
 // SetCallback sets a callback object for the scanner. For every event
 // emitted by libyara during subsequent scan, the appropriate method
-// on the ScanCallback object is called.
+// on the ScanCallback object will be called.
 //
 // For the common case where only a list of matched rules is relevant,
 // setting a callback object is not necessary.
 func (s *Scanner) SetCallback(cb ScanCallback) *Scanner {
 	s.Callback = cb
+	s.prepared = false
 	return s
 }
 
@@ -168,16 +174,19 @@ func (s *Scanner) ScanMem(buf []byte) (err error) {
 	if len(buf) > 0 {
 		ptr = (*C.uint8_t)(unsafe.Pointer(&(buf[0])))
 	}
-	s.putCallbackData()
-	// SCAN_FLAGS_NO_TRYCATCH disables the YARA's exception handler that
-	// captures segfaults. Capturing these exceptions only makes sense
-	// while scanning memory-mapped files. When scanning in-memory data
-	// the excepton-handling mechanism doesn't have any benefit and only
-	// causes trouble, as it can interfere with golang's ability to detect
-	// null-pointer dereferences and panic accordingly.
-	C.yr_scanner_set_flags(
-		s.cptr,
-		s.flags.withReportFlags(s.Callback)|C.SCAN_FLAGS_NO_TRYCATCH)
+	if !s.prepared {
+		s.putCallbackData()
+		// SCAN_FLAGS_NO_TRYCATCH disables the YARA's exception handler that
+		// captures segfaults. Capturing these exceptions only makes sense
+		// while scanning memory-mapped files. When scanning in-memory data
+		// the excepton-handling mechanism doesn't have any benefit and only
+		// causes trouble, as it can interfere with golang's ability to detect
+		// null-pointer dereferences and panic accordingly.
+		C.yr_scanner_set_flags(
+			s.cptr,
+			s.flags.withReportFlags(s.Callback)|C.SCAN_FLAGS_NO_TRYCATCH)
+		s.prepared = true
+	}
 	err = s.newScanError(C.yr_scanner_scan_mem(
 		s.cptr,
 		ptr,


### PR DESCRIPTION
sec: update go-git to `5.19.1`
sec: update x/text to `0.39.0`
feat: optimise `yr` scanner flag and callback tracking
refactor: preallocate expire check `stat`
doc: remove retired `goreportcard`
doc: bump download release

Flag and callback handling with yara scanner `c` binding optimised for our use case. The larger the files are, the more this improvement shines.

File expire stats are now always preallocated, so that eliminates one op per file (after first one!).

Vulnerabilities affecting `go-git` as `GO-2026-5336`, `GO-2026-5496` and `GO-2026-5693` resolved https://pkg.go.dev/vuln/GO-2026-5336 https://pkg.go.dev/vuln/GO-2026-5496 https://pkg.go.dev/vuln/GO-2026-5693 This project was unaffected by these third party vulnerabilities.

Vulnerability affecting `x/text` as `GO-2026-5970` resolved https://pkg.go.dev/vuln/GO-2026-5970 This project was unaffected by this third party vulnerability.